### PR TITLE
Added support for fetching QE Identity information

### DIFF
--- a/src/curl_easy.cpp
+++ b/src/curl_easy.cpp
@@ -86,6 +86,10 @@ std::unique_ptr<curl_easy> curl_easy::create(
     easy->set_opt_or_throw(CURLOPT_HEADERFUNCTION, &header_callback);
     easy->set_opt_or_throw(CURLOPT_HEADERDATA, easy.get());
     easy->set_opt_or_throw(CURLOPT_FAILONERROR, 1L);
+    // verify the server's SSL certificate
+    easy->set_opt_or_throw(CURLOPT_SSL_VERIFYPEER, 1L);
+    // verify server certificate's name against host name
+    easy->set_opt_or_throw(CURLOPT_SSL_VERIFYHOST, 2L);
 
 #ifdef __LINUX__
     if (!ca_cert.empty())

--- a/src/curl_easy.h
+++ b/src/curl_easy.h
@@ -79,16 +79,12 @@ class curl_easy
         void* ssl_context,
         void* user_data);
 
-    static void throw_on_error(
-        CURLcode code,
-        const std::string& function)
+    static void throw_on_error(CURLcode code, const std::string& function)
     {
         throw_on_error(code, function.c_str());
     }
 
-    static void throw_on_error(
-        CURLcode code,
-        const char* function);
+    static void throw_on_error(CURLcode code, const char* function);
 
     // Wraps curl_easy_setopt operations which are not ever supposed to fail.
     template <typename T>

--- a/src/dcap_provider.h
+++ b/src/dcap_provider.h
@@ -51,12 +51,10 @@ typedef struct _sgx_ql_crl_data_t
 typedef struct _sgx_ql_revocation_info_t
 {
     sgx_ql_revocation_info_version_t version;
-
-    uint32_t tcb_info_size;         // size of tcb_info
-    char* tcb_info;                 // Intel-signed TCB info structure (JSON)
+    uint32_t tcb_info_size; // size of tcb_info
+    char* tcb_info; // null-terminated Intel-signed TCB info structure (JSON)
     uint32_t tcb_issuer_chain_size; // size of issuer chain for TCB info
-    char* tcb_issuer_chain;         // PEM-encoded certificate chain
-
+    char* tcb_issuer_chain;  // null-terminated PEM-encoded certificate chain
     uint32_t crl_count;      // number of CRL data blobs returned
     sgx_ql_crl_data_t* crls; // array of CRL data blobs
 } sgx_ql_revocation_info_t;
@@ -67,6 +65,24 @@ typedef sgx_plat_error_t (*sgx_ql_get_revocation_info_t)(
 
 typedef void (*sgx_ql_free_revocation_info_t)(
     sgx_ql_revocation_info_t* p_revocation_info);
+
+/*****************************************************************************
+ * Data types and interfaces for getting qe identity info
+ ****************************************************************************/
+
+typedef struct _sgx_qe_identity_info_t
+{
+    uint32_t qe_id_info_size; // size of qe identity
+    char* qe_id_info; // null-terminated qe identity info structure (JSON)
+    uint32_t issuer_chain_size; // size of issuer chain for qe identity info
+    char* issuer_chain;         // null-terminated PEM-encoded certificate chain
+} sgx_qe_identity_info_t;
+
+typedef sgx_plat_error_t (*sgx_get_qe_identity_info_t)(
+    sgx_qe_identity_info_t** pp_qe_identity_info);
+
+typedef void (*sgx_free_qe_identity_info_t)(
+    sgx_qe_identity_info_t* p_qe_identity_info);
 
 /*****************************************************************************
  * Data types and interfaces for configuration the platform quote provider


### PR DESCRIPTION
This PR adds two new functions: sgx_get_qe_identity_info() and sgx_free_qe_identity_info() to support fetching Quote Enclave Identity Information. They will be called from Intel SGX DCAP library from Open Enclave SDK's oe_verify_report API implementation.

Before the Azure PCK service supports caching qe identity information, the changes in this PR fetch Quote Enclave Identity information directly from Intel server "https://api.trustedservices.intel.com/sgx/certification/v1/qe/identity".
