### PR TITLE
Properly use custom libdcap_quoteprov.so build for CI

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -20,7 +20,7 @@ def coffeelakeTest(String compiler, String suite) {
             dir('openenclave') {
                 git url: 'https://github.com/Microsoft/openenclave.git'
                 timeout(15) {
-                    sh "LD_LIBRARY_PATH=$WORKSPACE/src/Linux ./scripts/test-build-config -p  SGX1FLC -b $suite -d --compiler=$compiler"
+                    sh "LD_LIBRARY_PATH=$WORKSPACE/src/Linux LD_PRELOAD=$WORKSPACE/src/Linux/libdcap_quoteprov.so ./scripts/test-build-config -p  SGX1FLC -b $suite -d --compiler=$compiler"
                 }
             }
         }


### PR DESCRIPTION
In order to make sure that the custom `libdcap_quoteprov.so` library is used by the CI, we have to set `LD_PRELOAD` environment variable as well.