### PR TITLE
Fix Dockerfile

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,4 +1,12 @@
-FROM ubuntu:16.04 
+FROM ubuntu:16.04
+
+ARG UNAME=jenkins
+ARG GNAME=jenkins
+ARG UID=1001
+ARG GID=1001
+
+RUN groupadd --gid ${GID} ${GNAME} && \
+    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}
 
 RUN apt-get update \
     && apt-get install -y \
@@ -8,4 +16,3 @@ RUN apt-get update \
     libcurl4-openssl-dev \
     libssl-dev \
     wget
-


### PR DESCRIPTION
The Docker image used to build the Azure-DCAP-Client deb packages
lacked the particular user used by Jenkins to execute commands
inside the container.

This meant that commands were executed under an unknown user,
causing some binaries termiante with "Segmentation fault" error.