### PR TITLE
Jenkinsfile: Update the node labels

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ OETOOLS_IMAGE = "oejenkinscidockerregistry.azurecr.io/oetools-azure:1.8"
 // Tests running on hardware with custom path to libdcap_quoteprov.so
 def coffeelakeTest(String compiler, String suite) {
     stage("Coffeelake $compiler SGX1-FLC $suite") {
-        node('hardware') {
+        node('ACC-1604') {
             ws("$HOME/workspace/$JOB_NAME/$BUILD_ID") {
               cleanWs()
               checkout scm
@@ -33,7 +33,7 @@ def coffeelakeTest(String compiler, String suite) {
 // Test using oetools-test Docker image with /dev/sgx mounted inside container
 def nonSimulationTest() {
     stage('Non-Simulation Container SGX1-FLC RelWithDebInfo') {
-        node('hardware') {
+        node('ACC-1604') {
           ws("$HOME/workspace/$JOB_NAME/$BUILD_ID") {
             cleanWs()
             checkout scm


### PR DESCRIPTION
Since PR https://github.com/Microsoft/openenclave/pull/1248, the `hardware` label is deprecated.

Right now, we have `ACC-1604` and `ACC-1804` for a better separation of
the tested Ubuntu releases.

The previous `hardware` label will be converted to `ACC-1604`. In the future,
once Ubuntu 18.04 is validated, we'll be adding tests for `ACC-1804` as well.