### PR TITLE
Add dynamic user and group to docker images

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-ARG UNAME=jenkins
-ARG GNAME=jenkins
-ARG UID=1001
-ARG GID=1001
+ARG UNAME
+ARG GNAME
+ARG UID
+ARG GID
 
 RUN groupadd --gid ${GID} ${GNAME} && \
     useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -9,8 +9,11 @@ def coffeelakeTest(String compiler, String suite) {
               cleanWs()
               checkout scm
 
+              // Get Jenkins user and group for docker image
+              def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn)"
+
               // Generate libdcap_quoteprov.so in the $WORKSPACE/src/Linux folder
-              def buildImage = docker.build("az-dcap-builder", '.jenkins')
+              def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
               buildImage.inside {
                   dir('src/Linux') {
                       sh './configure'
@@ -38,8 +41,11 @@ def nonSimulationTest() {
             cleanWs()
             checkout scm
 
+            // Get Jenkins user and group for docker image
+            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn)"
+
             // build az-dcap-client deb package
-            def buildImage = docker.build("az-dcap-builder", '.jenkins')
+            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
             buildImage.inside {
                 dir('src/Linux') {
                     sh 'dpkg-buildpackage -us -uc'


### PR DESCRIPTION
The idea is to dynamically get the Jenkins UID GID user name and group name to create a valid user inside the image.

The Dockerfile was hard-coded with Jenkins user and group (1001) and that may not be the case, as well in the Jenkinsfile the user / group was not passed when the images are built and if the Jenkins user is not 1001 this would create the wrong user inside the docker image.
