### PR TITLE
Fix docker privileged mode

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -59,7 +59,7 @@ def nonSimulationTest() {
             Install az-dcap-client in the container from the deb package we previously built
             */
             def oetoolsImage = docker.build("oetools-test", "-f openenclave/.jenkins/Dockerfile ./openenclave")
-            oetoolsImage.inside('-u root --privileged -v /dev/sgx:/dev/sgx') {
+            oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
                 dir('src') {
                     sh 'apt remove -y az-dcap-client'
                     sh 'dpkg -i *.deb'


### PR DESCRIPTION
Use --device flag for docker when SGX is needed instead of --privileged mode to restrict what can be accessed on the host