### PR TITLE
Add CI testing stage for OE release package on Ubuntu 16.04

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -95,6 +95,56 @@ def ACCContainerTest() {
     }
 }
 
+def ACCTestOeRelease(String label, String ubuntu_version) {
+    stage("OpenEnclave release samples ${label}") {
+        node("${label}") {
+            ws("$HOME/workspace/$JOB_NAME/$BUILD_ID") {
+                cleanWs()
+                checkout scm
+
+                // Get Jenkins user and group for docker image
+                def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn)"
+
+                // build az-dcap-client deb package
+                def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+                buildImage.inside {
+                    dir('src/Linux') {
+                        sh 'dpkg-buildpackage -us -uc'
+                    }
+                }
+
+                // Clone openenclave repo
+                dir('openenclave') {
+                    git url: 'https://github.com/Microsoft/openenclave.git'
+                }
+                /*
+                Use oetools-azure Dockerfile from Openenclave repository
+                Remove the installed az-dcap-client from the container
+                Install az-dcap-client in the container from the deb package we previously built
+                then install the open-enclave package and run the samples
+                */
+                def oeToolsBuildarg="--build-arg ubuntu_version=${ubuntu_version}"
+                def oetoolsImage = docker.build("oetools-test", "${oeToolsBuildarg} -f openenclave/.jenkins/Dockerfile ./openenclave")
+                oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
+                    dir('src') {
+                        sh 'apt remove -y az-dcap-client'
+                        sh 'dpkg -i *.deb'
+                        sh 'apt-get install -y open-enclave'
+                    }
+                    dir('samples') {
+                        timeout(5) {
+                            sh 'cp -r /opt/openenclave/share/openenclave/samples/* .'
+                            // this needs to be replaced with the documentation path of after the new oe release (
+                            sh '. /opt/openenclave/share/openenclaverc && make world'
+                        }
+                    }
+                    // We need to remove the build folder because is created as root
+                    sh 'rm -rf ./samples'
+                }
+            }
+        }
+    }
+}
 
 parallel "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { ACCContainerTest() },
          "ACC1604 clang-7 SGX1-FLC Debug"                   : { ACCTest('clang-7', 'Debug') },
@@ -102,4 +152,5 @@ parallel "Non-Simulation Container SGX1-FLC RelWithDebInfo" : { ACCContainerTest
          "ACC1604 clang-7 SGX1-FLC RelWithDebInfo"          : { ACCTest('clang-7', 'RelWithDebinfo') },
          "ACC1604 gcc SGX1-FLC Debug"                       : { ACCTest('gcc', 'Debug') },
          "ACC1604 gcc SGX1-FLC Release"                     : { ACCTest('gcc', 'Release') },
-         "ACC1604 gcc SGX1-FLC RelWithDebInfo"              : { ACCTest('gcc', 'RelWithDebInfo') }
+         "ACC1604 gcc SGX1-FLC RelWithDebInfo"              : { ACCTest('gcc', 'RelWithDebInfo') },
+         "ACC1604 OpenEnclave Release Test"                 : { ACCTestOeRelease('ACC-1604','16.04') }


### PR DESCRIPTION
Add CI testing stage using the official 16.04 OE package

this fixes the ubuntu 16.04 part of #30 