### PR TITLE
Remove root user access in container when running on host folder

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 ARG UBUNTU_VERSION=16.04
 FROM ubuntu:${UBUNTU_VERSION}
 
@@ -5,10 +7,6 @@ ARG UNAME
 ARG GNAME
 ARG UID
 ARG GID
-
-
-RUN groupadd --gid ${GID} ${GNAME} && \
-    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}
 
 RUN apt-get update \
     && apt-get install -y \
@@ -18,4 +16,6 @@ RUN apt-get update \
     libcurl4-openssl-dev \
     libssl-dev \
     pkg-config \
-    wget
+    wget && \
+    groupadd --gid ${GID} ${GNAME} && \
+    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}

--- a/.jenkins/Dockerfile.scripts
+++ b/.jenkins/Dockerfile.scripts
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+ARG ubuntu_version=16.04
+
+FROM oetools-test-${ubuntu_version}
+
+COPY src /az-dcap-client-src
+
+ARG oeinstall=false
+ARG UNAME=jenkins
+ARG GNAME=jenkins
+ARG UID=1001
+ARG GID=1001
+
+RUN cd /az-dcap-client-src && \
+    apt-get remove -y az-dcap-client && \
+    dpkg -i *.deb && \
+    rm -rf /az-dcap-client-src && \
+    if [ "$oeinstall" = "true" ]; then apt-get install -y open-enclave; fi && \
+    groupadd --gid ${GID} ${GNAME} && \
+    useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -69,12 +69,13 @@ def ACCContainerTest(String label, String version) {
             Remove the installed az-dcap-client from the container
             Install az-dcap-client in the container from the deb package we previously built
             */
-            def oetoolsImage = docker.build("oetools-test", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
-            oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
-                dir('src') {
-                    sh 'apt remove -y az-dcap-client'
-                    sh 'dpkg -i *.deb'
-                }
+            def oetoolsImage = docker.build("oetools-test-${version}", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            /*
+            This is build from oetoolsImage, must be built without cache so it actually installs
+            the current build of az-dcap-client from the .deb we just built
+            */
+            def testImage = docker.build("az-dcap-test-${version}", "--build-arg ubuntu_version=${version} --no-cache -f .jenkins/Dockerfile.scripts .")
+            testImage.inside('--device /dev/sgx:/dev/sgx') {
                 dir('openenclave/build') {
                     timeout(15) {
                         withEnv(["CC=clang-7","CXX=clang++-7"]) {
@@ -118,14 +119,14 @@ def ACCTestOeRelease(String label, String version) {
             Install az-dcap-client in the container from the deb package we previously built
             then install the open-enclave package and run the samples
             */
-            def oeToolsBuildarg="--build-arg ubuntu_version=${version}"
-            def oetoolsImage = docker.build("oetools-test", "${oeToolsBuildarg} -f openenclave/.jenkins/Dockerfile ./openenclave")
-            oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
-                dir('src') {
-                    sh 'apt remove -y az-dcap-client'
-                    sh 'dpkg -i *.deb'
-                    sh 'apt-get install -y open-enclave'
-                }
+            def oetoolsImage = docker.build("oetools-test-${version}", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            /*
+            This is build from oetoolsImage, musb be built without cache so it actually installs
+            the current build of az-dcap-client from the .deb we just built 
+            and installs open-enclave release candidate
+            */
+            def testImage = docker.build("az-dcap-test-${version}", "--build-arg ubuntu_version=${version} --build-arg oeinstall=true --no-cache -f .jenkins/Dockerfile.scripts .")
+            testImage.inside('--device /dev/sgx:/dev/sgx') {
                 dir('samples') {
                     timeout(5) {
                         sh 'cp -r /opt/openenclave/share/openenclave/samples/* .'
@@ -133,8 +134,6 @@ def ACCTestOeRelease(String label, String version) {
                         sh '. /opt/openenclave/share/openenclaverc && make world'
                     }
                 }
-                // We need to remove the build folder because is created as root
-                sh 'rm -rf ./samples'
             }
         }
     }


### PR DESCRIPTION
Besides the fact that it's not OK to use the `-u root` option for all commands, some runs would leave artifacts in the Jenkins work space even with line used previously to remove the build folder.

This change moves the installation steps of the image into an intermediary `Dockerfile.scripts` which must be run without docker cache on top of the oetools-tools image that is cached locally in order to install the currently built .deb package of az-dcap-client (and the open-enclave release, since it only unpacks in the /opt folder can use the same `Dockerfile.scripts` for both stages) and then run the tests in a container from that image with the Jenkins user in the mounted work-space folder