### PR TITLE
Remove explicit workspace set

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,35 +8,33 @@ def ACCTest(String label, String version, String compiler, String build_type) {
     }
     stage("${label} ${compiler} SGX1-FLC ${build_type}") {
         node("${label}") {
-            ws("${HOME}/workspace/${JOB_NAME}/${BUILD_ID}") {
-                cleanWs()
-                checkout scm
+            cleanWs()
+            checkout scm
 
-                // Get Jenkins user and group for docker image
-                def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            // Get Jenkins user and group for docker image
+            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
 
-                // Generate libdcap_quoteprov.so in the $WORKSPACE/src/Linux folder
-                def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
-                buildImage.inside {
-                    dir('src/Linux') {
-                        sh './configure'
-                        sh 'make'
-                    }
+            // Generate libdcap_quoteprov.so in the $WORKSPACE/src/Linux folder
+            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            buildImage.inside {
+                dir('src/Linux') {
+                    sh './configure'
+                    sh 'make'
                 }
+            }
 
-                // Run hardware tests using custom LD_PRELOAD
-                dir('openenclave') {
-                    git url: 'https://github.com/Microsoft/openenclave.git'
-                }
-                dir('openenclave/build') {
-                    withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}","LD_LIBRARY_PATH=${WORKSPACE}/src/Linux"]) {
-                        timeout(15) {
-                            sh """
-                            cmake ${WORKSPACE}/openenclave -DCMAKE_BUILD_TYPE=${build_type}
-                            make
-                            ctest --output-on-failure
-                            """
-                        }
+            // Run hardware tests using custom LD_PRELOAD
+            dir('openenclave') {
+                git url: 'https://github.com/Microsoft/openenclave.git'
+            }
+            dir('openenclave/build') {
+                withEnv(["CC=${c_compiler}","CXX=${cpp_compiler}","LD_LIBRARY_PATH=${WORKSPACE}/src/Linux"]) {
+                    timeout(15) {
+                        sh """
+                        cmake ${WORKSPACE}/openenclave -DCMAKE_BUILD_TYPE=${build_type}
+                        make
+                        ctest --output-on-failure
+                        """
                     }
                 }
             }
@@ -48,45 +46,43 @@ def ACCTest(String label, String version, String compiler, String build_type) {
 def ACCContainerTest(String label, String version) {
     stage("Ubuntu${version} Non-Simulation Container SGX1-FLC RelWithDebInfo") {
         node("${label}") {
-            ws("${HOME}/workspace/${JOB_NAME}/${BUILD_ID}") {
-                cleanWs()
-                checkout scm
+            cleanWs()
+            checkout scm
 
-                // Get Jenkins user and group for docker image
-                def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            // Get Jenkins user and group for docker image
+            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
 
-                // build az-dcap-client deb package
-                def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
-                buildImage.inside {
-                    dir('src/Linux') {
-                        sh 'dpkg-buildpackage -us -uc'
-                    }
+            // build az-dcap-client deb package
+            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            buildImage.inside {
+                dir('src/Linux') {
+                    sh 'dpkg-buildpackage -us -uc'
                 }
+            }
 
-                // Clone openenclave repo
-                dir('openenclave') {
-                    git url: 'https://github.com/Microsoft/openenclave.git'
+            // Clone openenclave repo
+            dir('openenclave') {
+                git url: 'https://github.com/Microsoft/openenclave.git'
+            }
+            /*
+            Use oetools-azure Dockerfile from Openenclave repository
+            Remove the installed az-dcap-client from the container
+            Install az-dcap-client in the container from the deb package we previously built
+            */
+            def oetoolsImage = docker.build("oetools-test", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
+                dir('src') {
+                    sh 'apt remove -y az-dcap-client'
+                    sh 'dpkg -i *.deb'
                 }
-                /*
-                Use oetools-azure Dockerfile from Openenclave repository
-                Remove the installed az-dcap-client from the container
-                Install az-dcap-client in the container from the deb package we previously built
-                */
-                def oetoolsImage = docker.build("oetools-test", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
-                oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
-                    dir('src') {
-                        sh 'apt remove -y az-dcap-client'
-                        sh 'dpkg -i *.deb'
-                    }
-                    dir('openenclave/build') {
-                        timeout(15) {
-                            withEnv(["CC=clang-7","CXX=clang++-7"]) {
-                                sh """
-                                cmake ${WORKSPACE}/openenclave -DCMAKE_BUILD_TYPE=RelWithDebInfo
-                                make
-                                ctest --output-on-failure
-                                """
-                            }
+                dir('openenclave/build') {
+                    timeout(15) {
+                        withEnv(["CC=clang-7","CXX=clang++-7"]) {
+                            sh """
+                            cmake ${WORKSPACE}/openenclave -DCMAKE_BUILD_TYPE=RelWithDebInfo
+                            make
+                            ctest --output-on-failure
+                            """
                         }
                     }
                 }
@@ -98,49 +94,47 @@ def ACCContainerTest(String label, String version) {
 def ACCTestOeRelease(String label, String version) {
     stage("OpenEnclave release samples ${label}") {
         node("${label}") {
-            ws("$HOME/workspace/$JOB_NAME/$BUILD_ID") {
-                cleanWs()
-                checkout scm
+            cleanWs()
+            checkout scm
 
-                // Get Jenkins user and group for docker image
-                def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            // Get Jenkins user and group for docker image
+            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
 
-                // build az-dcap-client deb package
-                def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
-                buildImage.inside {
-                    dir('src/Linux') {
-                        sh 'dpkg-buildpackage -us -uc'
+            // build az-dcap-client deb package
+            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            buildImage.inside {
+                dir('src/Linux') {
+                    sh 'dpkg-buildpackage -us -uc'
+                }
+            }
+
+            // Clone openenclave repo
+            dir('openenclave') {
+                git url: 'https://github.com/Microsoft/openenclave.git'
+            }
+            /*
+            Use oetools-azure Dockerfile from Openenclave repository
+            Remove the installed az-dcap-client from the container
+            Install az-dcap-client in the container from the deb package we previously built
+            then install the open-enclave package and run the samples
+            */
+            def oeToolsBuildarg="--build-arg ubuntu_version=${version}"
+            def oetoolsImage = docker.build("oetools-test", "${oeToolsBuildarg} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
+                dir('src') {
+                    sh 'apt remove -y az-dcap-client'
+                    sh 'dpkg -i *.deb'
+                    sh 'apt-get install -y open-enclave'
+                }
+                dir('samples') {
+                    timeout(5) {
+                        sh 'cp -r /opt/openenclave/share/openenclave/samples/* .'
+                        // this needs to be replaced with the documentation path of after the new oe release (
+                        sh '. /opt/openenclave/share/openenclaverc && make world'
                     }
                 }
-
-                // Clone openenclave repo
-                dir('openenclave') {
-                    git url: 'https://github.com/Microsoft/openenclave.git'
-                }
-                /*
-                Use oetools-azure Dockerfile from Openenclave repository
-                Remove the installed az-dcap-client from the container
-                Install az-dcap-client in the container from the deb package we previously built
-                then install the open-enclave package and run the samples
-                */
-                def oeToolsBuildarg="--build-arg ubuntu_version=${version}"
-                def oetoolsImage = docker.build("oetools-test", "${oeToolsBuildarg} -f openenclave/.jenkins/Dockerfile ./openenclave")
-                oetoolsImage.inside('-u root --device /dev/sgx:/dev/sgx') {
-                    dir('src') {
-                        sh 'apt remove -y az-dcap-client'
-                        sh 'dpkg -i *.deb'
-                        sh 'apt-get install -y open-enclave'
-                    }
-                    dir('samples') {
-                        timeout(5) {
-                            sh 'cp -r /opt/openenclave/share/openenclave/samples/* .'
-                            // this needs to be replaced with the documentation path of after the new oe release (
-                            sh '. /opt/openenclave/share/openenclaverc && make world'
-                        }
-                    }
-                    // We need to remove the build folder because is created as root
-                    sh 'rm -rf ./samples'
-                }
+                // We need to remove the build folder because is created as root
+                sh 'rm -rf ./samples'
             }
         }
     }


### PR DESCRIPTION
This pull request removes the explicit workspace used in `Jenkinsfile`.

We needed this workaround, because Jenkins trimmed the file paths in case they were too long. I renamed the Jenkins job from `Azure-DCAP-Client-Testing` to `Az-DCAP` in order to have shorter file paths from the default `WORKSPACE` directory set by Jenkins, and the CI succeeded.

The main reason we want to remove the explicit workspace set is because it's too static. We recently changed the default `WORKSPACE` directory to another location, and this `Jenkinsfile` had to be updated accordingly.