### PR TITLE
Add unified docker build-args to all stages

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-ARG UBUNTU_VERSION=16.04
-FROM ubuntu:${UBUNTU_VERSION}
+ARG ubuntu_version=16.04
+FROM ubuntu:${ubuntu_version}
 
 ARG UNAME
 ARG GNAME

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,3 +1,11 @@
+String dockerBuildArgs(String... args) {
+    String argumentString = ""
+    for(arg in args) {
+        argumentString += " --build-arg ${arg}"
+    }
+    return argumentString
+}
+
 // Tests running on hardware with custom path to libdcap_quoteprov.so
 def ACCTest(String label, String version, String compiler, String build_type) {
     def c_compiler = "clang-7"
@@ -12,10 +20,14 @@ def ACCTest(String label, String version, String compiler, String build_type) {
             checkout scm
 
             // Get Jenkins user and group for docker image
-            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            String buildArgs = dockerBuildArgs("UID=\$(id -u)",
+                                               "GID=\$(id -g)",
+                                               "UNAME=\$(id -un)",
+                                               "GNAME=\$(id -gn)",
+                                               "ubuntu_version=${version}")
 
             // Generate libdcap_quoteprov.so in the $WORKSPACE/src/Linux folder
-            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            def buildImage = docker.build("az-dcap-builder", "${buildArgs} ${WORKSPACE}/.jenkins")
             buildImage.inside {
                 dir('src/Linux') {
                     sh './configure'
@@ -50,10 +62,14 @@ def ACCContainerTest(String label, String version) {
             checkout scm
 
             // Get Jenkins user and group for docker image
-            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            String buildArgs = dockerBuildArgs("UID=\$(id -u)",
+                                               "GID=\$(id -g)",
+                                               "UNAME=\$(id -un)",
+                                               "GNAME=\$(id -gn)",
+                                               "ubuntu_version=${version}")
 
             // build az-dcap-client deb package
-            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            def buildImage = docker.build("az-dcap-builder", "${buildArgs} ${WORKSPACE}/.jenkins")
             buildImage.inside {
                 dir('src/Linux') {
                     sh 'dpkg-buildpackage -us -uc'
@@ -69,12 +85,12 @@ def ACCContainerTest(String label, String version) {
             Remove the installed az-dcap-client from the container
             Install az-dcap-client in the container from the deb package we previously built
             */
-            def oetoolsImage = docker.build("oetools-test-${version}", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile ./openenclave")
             /*
             This is build from oetoolsImage, must be built without cache so it actually installs
             the current build of az-dcap-client from the .deb we just built
             */
-            def testImage = docker.build("az-dcap-test-${version}", "--build-arg ubuntu_version=${version} --no-cache -f .jenkins/Dockerfile.scripts .")
+            def testImage = docker.build("az-dcap-test-${version}", "${buildArgs} --no-cache -f .jenkins/Dockerfile.scripts .")
             testImage.inside('--device /dev/sgx:/dev/sgx') {
                 dir('openenclave/build') {
                     timeout(15) {
@@ -99,10 +115,14 @@ def ACCTestOeRelease(String label, String version) {
             checkout scm
 
             // Get Jenkins user and group for docker image
-            def dockerBuildArgs = "--build-arg UID=\$(id -u) --build-arg GID=\$(id -g) --build-arg UNAME=\$(id -un) --build-arg GNAME=\$(id -gn) --build-arg UBUNTU_VERSION=${version}"
+            String buildArgs = dockerBuildArgs("UID=\$(id -u)",
+                                               "GID=\$(id -g)",
+                                               "UNAME=\$(id -un)",
+                                               "GNAME=\$(id -gn)",
+                                               "ubuntu_version=${version}")
 
             // build az-dcap-client deb package
-            def buildImage = docker.build("az-dcap-builder", "${dockerBuildArgs} ${WORKSPACE}/.jenkins")
+            def buildImage = docker.build("az-dcap-builder", "${buildArgs} ${WORKSPACE}/.jenkins")
             buildImage.inside {
                 dir('src/Linux') {
                     sh 'dpkg-buildpackage -us -uc'
@@ -119,13 +139,14 @@ def ACCTestOeRelease(String label, String version) {
             Install az-dcap-client in the container from the deb package we previously built
             then install the open-enclave package and run the samples
             */
-            def oetoolsImage = docker.build("oetools-test-${version}", "--build-arg ubuntu_version=${version} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile ./openenclave")
             /*
             This is build from oetoolsImage, musb be built without cache so it actually installs
             the current build of az-dcap-client from the .deb we just built 
             and installs open-enclave release candidate
             */
-            def testImage = docker.build("az-dcap-test-${version}", "--build-arg ubuntu_version=${version} --build-arg oeinstall=true --no-cache -f .jenkins/Dockerfile.scripts .")
+            buildArgs += dockerBuildArgs("oeinstall=true")
+            def testImage = docker.build("az-dcap-test-${version}", "${buildArgs} --no-cache -f .jenkins/Dockerfile.scripts .")
             testImage.inside('--device /dev/sgx:/dev/sgx') {
                 dir('samples') {
                     timeout(5) {


### PR DESCRIPTION
Since the docker images need about the same build args we can add them only once in order to make the code more readable,

Add groovy function to concatenate all docker build args in a more organized manner.

Unified the Dockerfile `ubuntu_version` to be without caps like in the open-enclave image Dockerfile so we can build with the same build args the Jenkins user args should not be consumed by the open-enclave Dockerfile since they are not defined in it

