### PR TITLE
Added environment variable override of cert_base_url for integration testing

### DIFF
--- a/src/Linux/local_cache.cpp
+++ b/src/Linux/local_cache.cpp
@@ -183,14 +183,14 @@ static void make_dir(const std::string& dirname, mode_t mode)
 static void init_callback()
 {
     const char * env_home = ::getenv("HOME");
-    const char * env_azdcapcache = ::getenv("AZDCAPCACHE");
+    const char * env_azdcap_cache = ::getenv("AZDCAP_CACHE");
     const std::string application_name("/.az-dcap-client/");
     
     std::string dirname;
 
-    if (env_azdcapcache != 0 && (strcmp(env_azdcapcache,"") != 0))
+    if (env_azdcap_cache != 0 && (strcmp(env_azdcap_cache,"") != 0))
     {
-        dirname = env_azdcapcache;
+        dirname = env_azdcap_cache;
     }
     else if (env_home != 0 && (strcmp(env_home,"") != 0))
     {

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -29,14 +29,24 @@ static sgx_ql_free_revocation_info_t sgx_ql_free_revocation_info;
 static sgx_ql_get_revocation_info_t sgx_ql_get_revocation_info;
 static sgx_ql_free_quote_config_t sgx_ql_free_quote_config;
 static sgx_ql_get_quote_config_t sgx_ql_get_quote_config;
-static sgx_ql_set_base_url_t sgx_ql_set_base_url;
 static sgx_ql_set_logging_function_t sgx_ql_set_logging_function;
 
 static void Log(sgx_ql_log_level_t level, const char* message)
 {
+    char const * levelText = "ERROR";
+    switch (level) {
+        case SGX_QL_LOG_WARNING:
+            levelText = "WARNING";
+            break;
+        case SGX_QL_LOG_INFO:
+            levelText = "INFO";
+            break;
+        default:
+	    levelText = "ERROR";
+    }
     printf(
         "[%s]: %s\n",
-        level == SGX_QL_LOG_ERROR ? "ERROR" : "INFO",
+        levelText,
         message);
 }
 
@@ -61,9 +71,6 @@ static void* LoadFunctions()
 
     sgx_ql_get_quote_config = reinterpret_cast<sgx_ql_get_quote_config_t>(dlsym(library, "sgx_ql_get_quote_config"));
     assert(sgx_ql_get_quote_config);
-
-    sgx_ql_set_base_url = reinterpret_cast<sgx_ql_set_base_url_t>(dlsym(library, "sgx_ql_set_base_url"));
-    assert(sgx_ql_set_base_url);
 
     sgx_ql_set_logging_function = reinterpret_cast<sgx_ql_set_logging_function_t>(dlsym(library, "sgx_ql_set_logging_function"));
     assert(sgx_ql_set_logging_function);
@@ -163,7 +170,7 @@ extern void QuoteProvTests()
     //
     // First pass: Get the data from the service, no cache allowed
     //
-    sgx_ql_set_base_url("https://global.acccache.azure.net/sgx/certificates");
+    setenv("AZDCAP_BASE_CERT_URL", "https://global.acccache.azure.net/sgx/certificates", 1);
     local_cache_clear();
 
     start = std::clock();

--- a/src/Windows/dcap_provider.def
+++ b/src/Windows/dcap_provider.def
@@ -4,5 +4,4 @@ EXPORTS
     sgx_ql_free_quote_config
     sgx_ql_get_revocation_info
     sgx_ql_free_revocation_info
-    sgx_ql_set_base_url
     sgx_ql_set_logging_function

--- a/src/dcap_provider.h
+++ b/src/dcap_provider.h
@@ -90,6 +90,7 @@ typedef void (*sgx_free_qe_identity_info_t)(
  ****************************************************************************/
 typedef enum _sgx_ql_log_level_t {
     SGX_QL_LOG_ERROR,
+    SGX_QL_LOG_WARNING,
     SGX_QL_LOG_INFO
 } sgx_ql_log_level_t;
 
@@ -100,9 +101,5 @@ typedef void (
 /// Set the callback used for recording log information.
 typedef sgx_plat_error_t (*sgx_ql_set_logging_function_t)(
     sgx_ql_logging_function_t logger);
-
-/// Set the base URL for the certificate host service. This is typically done
-/// for testing.
-typedef sgx_plat_error_t (*sgx_ql_set_base_url_t)(const char* url);
 
 #endif // #ifndef PLATFORM_QUOTE_PROVIDER_H


### PR DESCRIPTION
This PR adds the ability to specify the environment variable "AZURE_BASE_CERT_URL" to contain the base URL, which will then override the base_cert_url in this library. This environment variable can be used for integration testing consumers of the Azure-DCAP-Client (like Open Enclave) against alternative cert/CRL/TCBInfo endpoints.

I added a new "WARNING" log level, which will be utilized if this environment variable is set.

Considerations: It feels a little awkward to have two ways of specifying the base_cert_url, one being this environment variable, and the other being the "sgx_ql_set_base_url" function. This function offers a little less utility, because it must be called by the consumers of this library, instead of being able to be specified in an environment, and that makes integration testing against custom endpoints a bit more difficult. So, should we remove sgx_ql_set_base_url? Or keep both around? 

Tagging @soccerGB @msft-jonnadul, and feel free to tag others