### PR TITLE
Add CI testing stage for OE release package on Ubuntu 18.04

### DIFF
--- a/.jenkins/Dockerfile.scripts
+++ b/.jenkins/Dockerfile.scripts
@@ -16,6 +16,6 @@ RUN cd /az-dcap-client-src && \
     apt-get remove -y az-dcap-client && \
     dpkg -i *.deb && \
     rm -rf /az-dcap-client-src && \
-    if [ "$oeinstall" = "true" ]; then apt-get install -y open-enclave; fi && \
+    if [ "$oeinstall" = "true" ]; then apt-get update && apt-get install -y open-enclave; fi && \
     groupadd --gid ${GID} ${GNAME} && \
     useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -174,4 +174,5 @@ parallel "ACC1604 SGX1-FLC Container RelWithDebInfo" : { ACCContainerTest('ACC-1
          "ACC1804 SGX1-FLC gcc Debug" :                { ACCTest('ACC-1804', '18.04', 'gcc', 'Debug') },
          "ACC1804 SGX1-FLC gcc Release" :              { ACCTest('ACC-1804', '18.04', 'gcc', 'Release') },
          "ACC1804 SGX1-FLC gcc RelWithDebInfo" :       { ACCTest('ACC-1804', '18.04', 'gcc', 'RelWithDebInfo') },
-         "ACC1604 OpenEnclave Release Test" :          { ACCTestOeRelease('ACC-1604','16.04') }
+         "ACC1604 OpenEnclave Release Test" :          { ACCTestOeRelease('ACC-1604','16.04') },
+         "ACC1804 OpenEnclave Release Test" :          { ACCTestOeRelease('ACC-1804','18.04') }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -141,8 +141,8 @@ def ACCTestOeRelease(String label, String version) {
             */
             def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile ./openenclave")
             /*
-            This is build from oetoolsImage, musb be built without cache so it actually installs
-            the current build of az-dcap-client from the .deb we just built 
+            This is build from oetoolsImage, must be built without cache so it actually installs
+            the current build of az-dcap-client from the .deb we just built
             and installs open-enclave release candidate
             */
             buildArgs += dockerBuildArgs("oeinstall=true")
@@ -150,9 +150,13 @@ def ACCTestOeRelease(String label, String version) {
             testImage.inside('--device /dev/sgx:/dev/sgx') {
                 dir('samples') {
                     timeout(5) {
-                        sh 'cp -r /opt/openenclave/share/openenclave/samples/* .'
-                        // this needs to be replaced with the documentation path of after the new oe release (
-                        sh '. /opt/openenclave/share/openenclaverc && make world'
+                        sh '''. /opt/openenclave/share/openenclave/openenclaverc
+                            cp -r /opt/openenclave/share/openenclave/samples/ ~/samples
+                            for DIR in $(find ~/samples/* -maxdepth 0 -type d); do
+                              cd $DIR
+                              make build
+                              make run
+                            done'''
                     }
                 }
             }


### PR DESCRIPTION
Fixes 2nd bullet from checklist in https://github.com/Microsoft/Azure-DCAP-Client/issues/30 by adding a stage to test also OE release package for Ubuntu 18.04