### PR TITLE
Add Jenkinsfile to build the Docker images

### DIFF
--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,21 +1,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-ARG ubuntu_version=16.04
+
+ARG ubuntu_version=18.04
+
 FROM ubuntu:${ubuntu_version}
 
-ARG UNAME
-ARG GNAME
-ARG UID
-ARG GID
+ARG UNAME=jenkins
+ARG GNAME=jenkins
+ARG UID=1001
+ARG GID=1001
 
-RUN apt-get update \
-    && apt-get install -y \
-    build-essential \
-    curl \
-    debhelper \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    pkg-config \
-    wget && \
+RUN apt-get update && \
+    apt-get install -y build-essential curl debhelper libcurl4-openssl-dev \
+                       libssl-dev pkg-config wget && \
     groupadd --gid ${GID} ${GNAME} && \
     useradd --create-home --uid ${UID} --gid ${GID} --shell /bin/bash ${UNAME}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -85,7 +85,7 @@ def ACCContainerTest(String label, String version) {
             Remove the installed az-dcap-client from the container
             Install az-dcap-client in the container from the deb package we previously built
             */
-            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile.full ./openenclave")
             /*
             This is build from oetoolsImage, must be built without cache so it actually installs
             the current build of az-dcap-client from the .deb we just built
@@ -139,7 +139,7 @@ def ACCTestOeRelease(String label, String version) {
             Install az-dcap-client in the container from the deb package we previously built
             then install the open-enclave package and run the samples
             */
-            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile ./openenclave")
+            def oetoolsImage = docker.build("oetools-test-${version}", "${buildArgs} -f openenclave/.jenkins/Dockerfile.full ./openenclave")
             /*
             This is build from oetoolsImage, must be built without cache so it actually installs
             the current build of az-dcap-client from the .deb we just built

--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -1,0 +1,32 @@
+@Library("OpenEnclaveCommon") _
+oe = new jenkins.common.Openenclave()
+
+OETOOLS_REPO = "https://oejenkinscidockerregistry.azurecr.io"
+OETOOLS_REPO_CREDENTIAL_ID = "oejenkinscidockerregistry"
+
+def buildDockerImages() {
+    node("nonSGX") {
+        stage("Checkout") {
+            cleanWs()
+            checkout scm
+        }
+        String buildArgs = oe.dockerBuildArgs("UID=\$(id -u)", "UNAME=\$(id -un)",
+                                              "GID=\$(id -g)", "GNAME=\$(id -gn)")
+        stage("Build Ubuntu 16.04 Docker Image") {
+            azDcapTools1604 = oe.dockerImage("az-dcap-tools-16.04:${DOCKER_TAG}", ".jenkins/Dockerfile", "${buildArgs} --build-arg ubuntu_version=16.04")
+        }
+        stage("Build Ubuntu 18.04 Docker Image") {
+            azDcapTools1804 = oe.dockerImage("az-dcap-tools-18.04:${DOCKER_TAG}", ".jenkins/Dockerfile", "${buildArgs} --build-arg ubuntu_version=18.04")
+        }
+        stage("Push to OE Docker Registry") {
+            docker.withRegistry(OETOOLS_REPO, OETOOLS_REPO_CREDENTIAL_ID) {
+                azDcapTools1604.push()
+                azDcapTools1804.push()
+                azDcapTools1604.push('latest')
+                azDcapTools1804.push('latest')
+            }
+        }
+    }
+}
+
+buildDockerImages()


### PR DESCRIPTION
* Add `.jenkins/build_docker_images.Jenkinsfile` to build the
  Docker images and   push them to the Jenkins private registry
* General cleanup to the `.jenkins/Dockerfile`
* Fix Dockerfile usage. This caused some recent CI failures