### PR TITLE
[CI/CD] Fix variables declaration

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -18,7 +18,7 @@ def ACCTest(String label, String version, String compiler, String build_type) {
             }
 
             // Run hardware tests using the libdcap_quoteprov.so build
-            task = """
+            def task = """
                     cd ${WORKSPACE}/src/Linux
                     ./configure
                     make
@@ -47,7 +47,7 @@ def ACCContainerTest(String label, String version) {
 
             // Run the OE tests from the git repository with the currently
             // generated az-dcap-client deb package installed
-            task = """
+            def task = """
                     cd ${WORKSPACE}/src/Linux
                     dpkg-buildpackage -us -uc
                     sudo dpkg -i ${WORKSPACE}/src/az-dcap-client_*_amd64.deb
@@ -70,7 +70,7 @@ def ACCTestOeRelease(String label, String version) {
 
             // Run the OE samples bundled with the published OE package, having
             // the currently generated az-dcap-client deb package installed
-            task = """
+            def task = """
                     cd ${WORKSPACE}/src/Linux
                     dpkg-buildpackage -us -uc
                     sudo dpkg -i ${WORKSPACE}/src/az-dcap-client_*_amd64.deb


### PR DESCRIPTION
Add `def` to the variables declaration, otherwise their scope
is global and might cause race conditions as reported here:
https://github.com/Microsoft/openenclave/pull/1719