### PR TITLE
Add SYS_PTRACE capability to Docker containers

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -57,7 +57,7 @@ def ACCContainerTest(String label, String version) {
                     ninja -v
                     ctest --output-on-failure
                    """
-            oe.ContainerRun("${DOCKER_REGISTRY}/az-dcap-tools-${version}", 'clang-7', task, '--device /dev/sgx:/dev/sgx')
+            oe.ContainerRun("${DOCKER_REGISTRY}/az-dcap-tools-${version}", 'clang-7', task, '--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx')
         }
     }
 }
@@ -84,7 +84,7 @@ def ACCTestOeRelease(String label, String version) {
                         make run
                     done
                    """
-            oe.ContainerRun("${DOCKER_REGISTRY}/az-dcap-tools-${version}", 'clang-7', task, '--device /dev/sgx:/dev/sgx')
+            oe.ContainerRun("${DOCKER_REGISTRY}/az-dcap-tools-${version}", 'clang-7', task, '--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx')
         }
     }
 }


### PR DESCRIPTION
Without this flag, the `oegdb-test` and `oegdb-test-simulation-mode`
unit tests will fail.

This change was already adopted in the upstream OE Jenkinsfile as
part of the commit https://github.com/Microsoft/openenclave/commit/138fe3bba2644e455b1fbfec2ba83420fc0c35fd.