### PR TITLE
Enhancements to dcap_provider.nuspec for windows to support debug and release packages

### DIFF
--- a/src/Windows/README.MD
+++ b/src/Windows/README.MD
@@ -1,13 +1,14 @@
 # Build
 1. Install Visual Studio 2017
 1. Open `src/Windows/dcap_provider.vcxproj`
-1. Build
+1. Save solution and Build in Debug X64 Configuration Mode
+1. Switch Configuration Mode to Release X64 mode and then Build
 
 # Packaging
 Run `nuget pack` in this directory. If you need to bump the version number
 or any other info, update the *.nuspec file.
 
-Note: You the output package includes:
+Note: Your output package includes:
   libcurl.dll
   libeay32.dll
   libssh2.dll

--- a/src/Windows/dcap_provider.nuspec
+++ b/src/Windows/dcap_provider.nuspec
@@ -17,8 +17,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="dcap_quoteprov.dll" target="lib" />
-    <file src="dcap_quoteprov.pdb" target="lib" />
-    <file src="dcap_provider.h" target="inc" />
+    <file src="x64\Debug\dcap_quoteprov.dll" target="lib\debug" />
+    <file src="x64\Debug\dcap_quoteprov.pdb" target="lib\debug" />
+    <file src="x64\Release\dcap_quoteprov.dll" target="lib\release" />
+    <file src="x64\Release\dcap_quoteprov.pdb" target="lib\release" />
+    <file src="..\dcap_provider.h" target="inc" />
   </files>
 </package>


### PR DESCRIPTION
Added paths to dcap_provider.nuspec for windows to facilitate building of Debug and Release packages.