### PR TITLE
Build refactoring to support Azure-DCAP-Client on Windows

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -98,7 +98,7 @@ def DCAPBuildTest(String label, String build_type) {
             bat """
                 vcvars64.bat x64 && \
                 cd ${WORKSPACE}\\src\\Windows && \
-                powershell.exe -ExecutionPolicy Bypass -Command \"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; .\\get-prereqs.ps1\" && \
+                powershell.exe -ExecutionPolicy Bypass -Command \".\\get-prereqs.ps1\" && \
                 powershell.exe -ExecutionPolicy Bypass -Command \"Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\\nuget.exe\" && \
                 nuget.exe restore dcap_provider.vcxproj -PackagesDirectory packages && \
                 MSBuild.exe dcap_provider.vcxproj /p:Configuration=${build_type};Platform=x64

--- a/src/Windows/README.MD
+++ b/src/Windows/README.MD
@@ -4,6 +4,15 @@
 1. Save solution and Build in Debug X64 Configuration Mode
 1. Switch Configuration Mode to Release X64 mode and then Build
 
+# Build from Powershell
+```powershell
+cd src\Windows
+.\get-prereqs.ps1
+.\build.ps1 -BuildType Debug
+```
+> If you get an error like the script cannot be loaded because the execution of scripts is disabled on this system, run `Set-ExecutionPolicy bypass` and accept the changes.
+
+
 # Packaging
 Run `nuget pack` in this directory. If you need to bump the version number
 or any other info, update the *.nuspec file.

--- a/src/Windows/build.ps1
+++ b/src/Windows/build.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  This script downloads the prerequisites and builds the project using MSBuild.
+  Release type is passed as an argument and can be either Debug or Release.
+.PARAMETER BuildType
+  The build to be performed
+.EXAMPLE
+  build.ps1 -BuildType Debug
+#>
+
+Param(
+    [ValidateSet("Debug", "Release")]
+    [string]$BuildType = "Debug"
+)
+
+function Set-VCVariables {
+    Param(
+        [string]$Version="15.0",
+        [string]$Platform="amd64"
+    )
+    if($Version -eq "15.0") {
+        $vcPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\"
+    } else {
+        $vcPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio $Version\VC\"
+    }
+    if($Version -eq "BuildTools") {
+        $vcPath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\"
+    }
+    $vcVars = cmd.exe /c "`"${vcPath}\vcvarsall.bat`" $Platform & set"
+    if($LASTEXITCODE -ne 0) { throw "Failed to get all VC variables" }
+    $vcVars | Foreach-Object {
+        if ($_ -match "=") {
+            $v = $_.split("=")
+            Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])"
+        }
+    }
+}
+
+Push-Location "$PSScriptRoot"
+Write-Output 'Setting Visual Studio environment variables'
+Set-VCVariables -Version 'BuildTools'
+Write-Output 'Restore packages with nuget'
+if(-not(Test-Path .\nuget.exe)) {
+    Write-Output 'Nuget not found! Downloading...'
+    Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\nuget.exe
+}
+.\nuget.exe restore dcap_provider.vcxproj -PackagesDirectory packages
+Write-Output ('Running build {0}' -f $BuildType)
+MSBuild.exe dcap_provider.vcxproj /p:Configuration=$BuildType /p:Platform=x64
+Pop-Location

--- a/src/Windows/get-prereqs.ps1
+++ b/src/Windows/get-prereqs.ps1
@@ -15,6 +15,8 @@ function fetch_from_intel_github
 
 mkdir -Force ext/intel | Out-Null
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 fetch_from_intel_github -path SGXDataCenterAttestationPrimitives/c27fe49f499104eda9364c7b048aff290fa00766/QuoteGeneration/psw/quote_wrapper/common/inc/sgx_ql_lib_common.h
 fetch_from_intel_github -path linux-sgx/1ccf25b64abd1c2eff05ead9d14b410b3c9ae7be/common/inc/sgx_report.h
 fetch_from_intel_github -path linux-sgx/1ccf25b64abd1c2eff05ead9d14b410b3c9ae7be/common/inc/sgx_key.h


### PR DESCRIPTION
- added a separate build file so that it's easier to use from the command line.
- added the security protocol to the get-prereqs.ps1 script since github requires Tls12 anyway.

Fixes https://github.com/microsoft/Azure-DCAP-Client/issues/62