### PR TITLE
Comment: GLOBAL_TIMEOUT refers to minutes

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,6 +1,8 @@
 // common lib definition
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
+
+// The below timeout is set in minutes
 GLOBAL_TIMEOUT = 240
 
 DOCKER_REGISTRY = "oejenkinscidockerregistry.azurecr.io"

--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -1,5 +1,7 @@
 @Library("OpenEnclaveCommon") _
 oe = new jenkins.common.Openenclave()
+
+// The below timeout is set in minutes
 GLOBAL_TIMEOUT = 240
 
 OETOOLS_REPO = "https://oejenkinscidockerregistry.azurecr.io"


### PR DESCRIPTION
Add a comment that GLOBAL_TIMEOUT in Jenkinsfiles refers to minutes.