### PR TITLE
Added documentation for how Azure caching service URLs are constructed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [src/Windows/README.MD](src/Windows/README.MD).
 
 The library builds the full URL of the artifacts served by the Azure-internal caching service from the parameters passed to the `sgx_ql_get_revocation_info_t` and `sgx_get_qe_identity_info_t` API calls. 
 
-For the certificate chain associated with an Intel SGX quote, each CRL Distribution Point is wrapped into an Azure-specific URL before being fetched by the Azure-DCAP-Client library. For example, the well-knwon Intel SGX Root CA CRL endpoint (https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl) is served by the Azure-internal caching service at: https://global.acccache.azure.net/sgx/certificates/pckcrl?uri=https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl&api-version=API_VERSION (where `API_VERSION` specifies the current API version).
+For the certificate chain associated with an Intel SGX quote, each CRL Distribution Point is wrapped into an Azure-specific URL before being fetched by the Azure-DCAP-Client library. For example, the well-known Intel SGX Root CA CRL endpoint (https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl) is served by the Azure-internal caching service at: https://global.acccache.azure.net/sgx/certificates/pckcrl?uri=https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl&api-version=API_VERSION (where `API_VERSION` specifies the current API version).
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ See [src/Linux/README.MD](src/Linux/README.MD).
 
 See [src/Windows/README.MD](src/Windows/README.MD).
 
+# Implementation
+
+The library builds the full URL of the artifacts served by the Azure-internal caching service from the parameters passed to the `sgx_ql_get_revocation_info_t` and `sgx_get_qe_identity_info_t` API calls. 
+
+For the certificate chain associated with an Intel SGX quote, each CRL Distribution Point is wrapped into an Azure-specific URL before being fetched by the Azure-DCAP-Client library. For example, the well-knwon Intel SGX Root CA CRL endpoint (https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl) is served by the Azure-internal caching service at: https://global.acccache.azure.net/sgx/certificates/pckcrl?uri=https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl&api-version=API_VERSION (where `API_VERSION` specifies the current API version).
+
 # Configuration
 
 The Azure-DCAP-Client library uses the following environment variables if set:


### PR DESCRIPTION
Last week, one of the SGX CRLs expired and the verification of the quotes (via Open Enclave's `oe_verify_report`) started to fail (https://github.com/microsoft/openenclave/issues/1842).

From a CCF standpoint, it wasn't clear what the cause of the issue was as the CRL Distribution Points in the Quote's certificate chain (i.e. https://api.trustedservices.intel.com/sgx/certification/v1/pckcrl?ca=processor and https://certificates.trustedservices.intel.com/IntelSGXRootCA.crl) seemed perfectly valid (as they had been updated by Intel). 

I believe that adding the following section in `README.md` would have helped us understand what was happening earlier/without having to delve into `dcap_provider.cpp`. 