### PR TITLE
Fix InstallAzureDCAP.ps1 script

### DIFF
--- a/src/Windows/GeneratePackage/InstallAzureDCAP.ps1
+++ b/src/Windows/GeneratePackage/InstallAzureDCAP.ps1
@@ -2,18 +2,45 @@ param (
     [Parameter(Mandatory=$true)][string]$localPath
 )
 
+
+function Add-ToSystemPath
+{
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string[]]$Path
+    )
+    if(!$Path)
+    {
+        return
+    }
+    $registryLocation = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+    $systemPath = (Get-ItemProperty -Path $registryLocation -Name Path).Path.Split(';')
+    $currentPath = $env:PATH.Split(';')
+    foreach($p in $Path)
+    {
+        if($p -notin $systemPath)
+        {
+            $systemPath += $p
+        }
+        if($p -notin $currentPath)
+        {
+            $currentPath += $p
+        }
+    }
+    $env:PATH = $currentPath -join ';'
+    $newSystemPath = $systemPath -join ';'
+    Set-ItemProperty -Path $registryLocation -Name Path -Value $newSystemPath
+}
+
+
 if (-not (Test-Path -Path $localPath))
 {
     Write-Host "$localPath does not exist, creating it."
     New-Item -ItemType Directory -Force -Path $localPath
 }
-else
-{
-    Write-Host "Copying dcap_quoteprov.dll into $localPath"
-    Copy-Item "..\build\native\dcap_quoteprov.dll" -Destination $localPath
-    
-    $newPath = $env:Path + ";$localPath"
 
-    Write-Host "Updating the system PATH variable with $localPath"
-    Set-ItemProperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path -Value $NewPath
-}
+Write-Host "Copying dcap_quoteprov.dll into $localPath"
+Copy-Item "..\build\native\dcap_quoteprov.dll" -Destination $localPath
+
+Write-Host "Updating the system PATH variable with $localPath"
+Add-ToSystemPath -Path $localPath


### PR DESCRIPTION
* Copy DLL even if destination directory doesn't exist already.
* Fix script idempotency. The `$localPath` is not appended to the
  system path if it already exists.
* Instead of using the `$env:Path`, which is a concatenation of
  the user path and system path, we use the existing value of the
  system path from registry.

Fixes https://github.com/microsoft/Azure-DCAP-Client/issues/95

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>