### PR TITLE
Add permissions tests for windows

### DIFF
--- a/src/Linux/Makefile.in
+++ b/src/Linux/Makefile.in
@@ -4,7 +4,12 @@
 prefix = /usr/local
 
 INCLUDES = -I##CURLINC## -I. -I.. -Iext/intel
-CFLAGS = -fPIC -std=c++14 -Wall -Werror $(INCLUDES) -D__LINUX__ -Wno-unknown-pragmas -pthread
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+    CFLAGS = -fPIC -std=c++14 -g -Wall -Werror $(INCLUDES) -D__LINUX__ -Wno-unknown-pragmas -pthread
+else
+    CFLAGS = -fPIC -std=c++14 -Wall -Werror $(INCLUDES) -D__LINUX__ -Wno-unknown-pragmas -pthread
+endif
 
 PROVIDER_SRC = ../dcap_provider.cpp ../logging.cpp curl_easy.cpp local_cache.cpp init.cpp
 PROVIDER_OBJ = $(PROVIDER_SRC:.cpp=.o)

--- a/src/Linux/README.MD
+++ b/src/Linux/README.MD
@@ -23,6 +23,8 @@ make install
     * Builds `libdcap_quoteprov.so`, the provider library.
 1. `make install` (optional)
     * Installs the library to `/usr/local/lib` and header to `/usr/local/include`.
+1. `make DEBUG=1` (optional)
+    * Builds the library with the -g flag for debugging
 
 # Packaging
 

--- a/src/Linux/README.MD
+++ b/src/Linux/README.MD
@@ -24,7 +24,7 @@ make install
 1. `make install` (optional)
     * Installs the library to `/usr/local/lib` and header to `/usr/local/include`.
 1. `make DEBUG=1` (optional)
-    * Builds the library with the -g flag for debugging
+    * Builds the library with the -g flag
 
 # Packaging
 

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -613,7 +613,7 @@ void RunCachePermissionTests(libary_type_t *library)
     TEST_START();
     #if defined __LINUX__
         auto permission_folder = "./test_permission";
-        auto permissions = {0700, 0400, 0200, 0000};
+        int permissions[] = {0700, 0400, 0200, 0000};
         setenv("AZDCAP_CACHE", permission_folder, 1);
     #else 
         auto permission_folder = ".\\test_permission";
@@ -641,10 +641,13 @@ void RunCachePermissionTests(libary_type_t *library)
     for (auto permission : permissions)
     {
         ReloadLibrary(library);
-        allow_access(permission_folder);
+        make_folder(permission_folder, permissions[0]);
         RunQuoteProviderTests(true);
+
         change_permission(permission_folder, permission);
+
         RunQuoteProviderTests(false);
+
         allow_access(permission_folder);
         remove_folder(permission_folder);
     }


### PR DESCRIPTION
- Add tests to validate the library can operate without the caching folder on Windows
- Add a debug flag to the makefile to build with debug symbols on Linux