### PR TITLE
[CI/CD] Fix Docker images build

### DIFF
--- a/.jenkins/build_docker_images.Jenkinsfile
+++ b/.jenkins/build_docker_images.Jenkinsfile
@@ -16,17 +16,21 @@ def buildDockerImages() {
                 checkout scm
             }
             stage("Build Ubuntu 16.04 Docker Image") {
-                azDcapTools1604 = oe.dockerImage("az-dcap-tools-16.04:${DOCKER_TAG}",
-                                                    ".jenkins/Dockerfile",
-                                                    "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=16.04")
+                docker.withRegistry(OETOOLS_REPO, OETOOLS_REPO_CREDENTIAL_ID) {
+                    azDcapTools1604 = oe.dockerImage("az-dcap-tools-16.04:${DOCKER_TAG}",
+                                                     ".jenkins/Dockerfile",
+                                                     "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=16.04")
+                }
                 pubazDcapTools1604 = oe.dockerImage("oeciteam/az-dcap-tools-16.04:${DOCKER_TAG}",
                                                     ".jenkins/Dockerfile",
                                                     "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=16.04")
             }
             stage("Build Ubuntu 18.04 Docker Image") {
-                azDcapTools1804 = oe.dockerImage("az-dcap-tools-18.04:${DOCKER_TAG}",
-                                                    ".jenkins/Dockerfile",
-                                                    "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=18.04")
+                docker.withRegistry(OETOOLS_REPO, OETOOLS_REPO_CREDENTIAL_ID) {
+                    azDcapTools1804 = oe.dockerImage("az-dcap-tools-18.04:${DOCKER_TAG}",
+                                                     ".jenkins/Dockerfile",
+                                                     "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=18.04")
+                }
                 pubazDcapTools1804 = oe.dockerImage("oeciteam/az-dcap-tools-18.04:${DOCKER_TAG}",
                                                     ".jenkins/Dockerfile",
                                                     "--build-arg UNAME=\$(id -un) --build-arg ubuntu_version=18.04")


### PR DESCRIPTION
The CI/CD Docker images built for testing inherit the OE Docker
images from the Azure private registry.

We need to make sure that the private registry is logged before
building the Azure-DCAP-Client CI/CD Docker images.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>