### PR TITLE
Cache all client collateral 

### DIFF
--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -378,16 +378,21 @@ constexpr auto CURL_TOLERANCE = 0.04;
 void RunQuoteProviderTests(bool caching_enabled=true)
 {
     std::clock_t start;
-    double duration_curl;
-    double duration_local;
+    double duration_curl_cert;
+    double duration_local_cert;
+    double duration_curl_verification;
+    double duration_local_verification;
     local_cache_clear();
 
     start = std::clock();
     GetCertsTest();
-    duration_curl = (std::clock() - start) / (double)CLOCKS_PER_SEC;
+    duration_curl_cert = (std::clock() - start) / (double)CLOCKS_PER_SEC;
 
     GetCrlTest();
+    
+    start = std::clock();
     GetVerificationCollateralTest();
+    duration_curl_verification = (std::clock() - start) / (double) CLOCKS_PER_SEC;
     GetRootCACrlTest();
 
 
@@ -396,19 +401,24 @@ void RunQuoteProviderTests(bool caching_enabled=true)
     //
     start = std::clock();
     GetCertsTest();
-    duration_local = (std::clock() - start) / (double)CLOCKS_PER_SEC;
+    duration_local_cert = (std::clock() - start) / (double)CLOCKS_PER_SEC;
 
     GetCrlTest();
     GetRootCACrlTest();
+
+    start = std::clock();
     GetVerificationCollateralTest();
+    duration_local_verification = (std::clock()) / (double) CLOCKS_PER_SEC;
 
     if (caching_enabled)
     {
         // Ensure that there is a signficiant enough difference between the cert
         // fetch to the end point and cert fetch to local cache and that local cache
         // call is fast enough
-        assert(fabs(duration_curl - duration_local) > CURL_TOLERANCE);
-        assert(duration_local < CURL_TOLERANCE);
+        assert(fabs(duration_curl_cert - duration_local_cert) > CURL_TOLERANCE);
+        assert(duration_local_cert < CURL_TOLERANCE);
+        assert(fabs(duration_curl_verification - duration_local_verification) > CURL_TOLERANCE);
+        assert(duration_local_verification < CURL_TOLERANCE);
     }
 }
 

--- a/src/Windows/dll/dcap_provider.def
+++ b/src/Windows/dll/dcap_provider.def
@@ -4,8 +4,6 @@ EXPORTS
     sgx_ql_free_quote_config
     sgx_ql_get_revocation_info
     sgx_ql_free_revocation_info
-    sgx_get_qe_identity_info
-    sgx_free_qe_identity_info
     sgx_ql_set_logging_function
     sgx_ql_free_quote_verification_collateral;
     sgx_ql_free_qve_identity;

--- a/src/Windows/dll/dcap_provider.def
+++ b/src/Windows/dll/dcap_provider.def
@@ -11,3 +11,5 @@ EXPORTS
     sgx_ql_get_quote_verification_collateral;
     sgx_ql_get_qve_identity;
     sgx_ql_get_root_ca_crl;
+    sgx_get_qe_identity_info
+    sgx_free_qe_identity_info

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -840,7 +840,7 @@ static quote3_error_t get_collateral(
     }
     catch (std::runtime_error& error)
     {
-        log(SGX_QL_LOG_ERROR,
+        log(SGX_QL_LOG_WARNING,
             "Runtime exception thrown, error: %s",
             error.what());
         // Swallow adding file to cache. Library can
@@ -985,7 +985,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
     }
     catch (std::runtime_error& error)
     {
-        log(SGX_QL_LOG_ERROR,
+        log(SGX_QL_LOG_WARNING,
             "Runtime exception thrown, error: %s",
             error.what());
         // Swallow adding file to cache. Library can
@@ -1403,7 +1403,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
             return operation_result;
         }
 
-        // Get QE Identity
+        // Get QE Identity & Issuer Chain
         std::string header_name;
         std::string qe_identity_url = build_enclave_id_url(false, header_name);
         const auto qe_identity_operation =


### PR DESCRIPTION
Addresses Issue #88 
- Cache CRLs, QE Identity ,and TCB Info for 12 hours 
- Continue caching PCK Certificates for 24 hours