### PR TITLE
Fix crash when no logging selected

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -28,6 +28,7 @@ def ACCTest(String label, String version, String compiler, String build_type) {
                         make
                         mkdir -p ${WORKSPACE}/openenclave/build
                         cd ${WORKSPACE}/openenclave/build
+                        git submodule update --recursive --init 
                         cmake ${WORKSPACE}/openenclave -G Ninja -DCMAKE_BUILD_TYPE=${build_type}
                         ninja -v
                         LD_LIBRARY_PATH=${WORKSPACE}/src/Linux ctest --output-on-failure
@@ -62,6 +63,7 @@ def ACCContainerTest(String label, String version) {
                         sudo dpkg -i ${WORKSPACE}/src/az-dcap-client_*_amd64.deb
                         mkdir -p ${WORKSPACE}/openenclave/build
                         cd ${WORKSPACE}/openenclave/build
+                        git submodule update --recursive --init
                         cmake ${WORKSPACE}/openenclave -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
                         ninja -v
                         ctest --output-on-failure

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -390,7 +390,7 @@ static inline float MeasureFunction(measured_function_t func)
                chrono::steady_clock::now() - start).count() / 1000000;
 }
 
-void RunQuoteProviderTests(bool caching_enabled = true)
+void RunQuoteProviderTests(bool caching_enabled = false)
 {
     local_cache_clear();
 

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -431,7 +431,7 @@ void RunQuoteProviderTests(bool caching_enabled = true)
     }
 }
 
-void ReloadLibrary(libary_type_t *library)
+void ReloadLibrary(libary_type_t *library, bool set_logging_callback = true)
 {
 #if defined __LINUX__
     dlclose(*library);
@@ -440,7 +440,10 @@ void ReloadLibrary(libary_type_t *library)
     FreeLibrary(*library);
     *library = LoadFunctions();
 #endif
-    assert(SGX_PLAT_ERROR_OK == sgx_ql_set_logging_function(Log));
+    if (set_logging_callback)
+    {
+        assert(SGX_PLAT_ERROR_OK == sgx_ql_set_logging_function(Log));
+    }
 }
 
 #ifndef __LINUX__
@@ -681,6 +684,13 @@ extern void QuoteProvTests()
     RunQuoteProviderTests();
     GetQveIdentityTest();
 
+    //
+    // Run tests without logging to make sure library can operate
+    // even if logging callback isn't set
+    //
+    ReloadLibrary(&library, false);
+    RunQuoteProviderTests();
+    GetQveIdentityTest();
     // 
     // Run tests to make sure libray can operate
     // even if access to filesystem is restricted

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -80,6 +80,17 @@ enum class CollateralTypes
     PckRootCrl
 };
 
+static std::string get_env_variable(std::string env_variable)
+{
+    std::string error_message;
+    auto retval = get_env_variabe_no_log(env_variable, error_message);
+    if (!error_message.empty())
+    {
+        log(SGX_QL_LOG_ERROR, error_message.c_str());
+    }
+    return retval;
+}
+
 static std::string get_collateral_version()
 {
     std::string collateral_version =

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -82,13 +82,12 @@ enum class CollateralTypes
 
 static std::string get_env_variable(std::string env_variable)
 {
-    std::string error_message;
-    auto retval = get_env_variabe_no_log(env_variable, error_message);
-    if (!error_message.empty())
+    auto retval = get_env_variable_no_log(env_variable);
+    if (!retval.second.empty())
     {
-        log(SGX_QL_LOG_ERROR, error_message.c_str());
+        log(SGX_QL_LOG_ERROR, retval.second.c_str());
     }
-    return retval;
+    return retval.first;
 }
 
 static std::string get_collateral_version()

--- a/src/environment.h
+++ b/src/environment.h
@@ -74,15 +74,4 @@ static std::string get_env_variabe_no_log(
     return std::string(env_value);
 }
 
-static std::string get_env_variable(std::string env_variable)
-{
-    std::string error_message;
-    auto retval = get_env_variabe_no_log(env_variable, error_message);
-    if (!error_message.empty())
-    {
-        log(SGX_QL_LOG_ERROR, error_message.c_str());
-    }
-    return retval;
-}
-
 #endif

--- a/src/environment.h
+++ b/src/environment.h
@@ -19,10 +19,10 @@
 #define MAX_ENV_VAR_LENGTH 2000
 
 #include <sstream>
+#include <utility>
 
-static std::string get_env_variabe_no_log(
-    std::string env_variable,
-    std::string& error_message)
+static std::pair<std::string, std::string> get_env_variable_no_log(
+    std::string env_variable)
 {
     const char* env_value;
     std::stringstream error_message_stream;
@@ -32,8 +32,7 @@ static std::string get_env_variabe_no_log(
     {
         error_message_stream << "Could not retreive environment variable for '"
                              << env_variable << "'";
-        error_message = error_message_stream.str();
-        return std::string();
+        return std::make_pair(std::string(), error_message_stream.str());
     }
 #else
     std::unique_ptr<char[]> env_temp =
@@ -43,8 +42,7 @@ static std::string get_env_variabe_no_log(
         error_message_stream
             << "Failed to allocate memory for environment varible for '"
             << env_variable << "'";
-        error_message = error_message_stream.str();
-        return std::string();
+        return std::make_pair(std::string(), error_message_stream.str());
     }
 
     env_value = env_temp.get();
@@ -54,8 +52,7 @@ static std::string get_env_variabe_no_log(
     {
         error_message_stream << "Could not retreive environment variable for '"
                              << env_variable << "'";
-        error_message = error_message_stream.str();
-        return std::string();
+        return std::make_pair(std::string(), error_message_stream.str());
     }
 #endif
     auto length = strnlen(env_value, MAX_ENV_VAR_LENGTH);
@@ -67,11 +64,10 @@ static std::string get_env_variabe_no_log(
                                 "length. ";
         error_message_stream << "Actual length is: " << length << " ";
         error_message_stream << "Max length is " << MAX_ENV_VAR_LENGTH;
-        error_message = error_message_stream.str();
-        return std::string();
+        return std::make_pair(std::string(), error_message_stream.str());
     }
 
-    return std::string(env_value);
+    return std::make_pair(env_value, std::string());
 }
 
 #endif

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -106,10 +106,19 @@ void init_debug_log()
     std::lock_guard<std::mutex> lock(log_init_mutex);
     if (!debug_log_initialized)
     {
-        auto log_level = get_env_variable(ENV_AZDCAP_DEBUG_LOG);
-        if (!log_level.empty())
+        std::string error_message;
+        auto log_level = get_env_variabe_no_log(ENV_AZDCAP_DEBUG_LOG, error_message);
+        if (!log_level.empty() && error_message.empty())
         {
             enable_debug_logging(log_level);
+        }
+
+        if (!error_message.empty())
+        {
+            printf(
+                "Azure Quote Provider: libdcap_quoteprov.so [%s]: %s\n",
+                log_level_string(SGX_QL_LOG_ERROR).c_str(),
+                error_message.c_str());
         }
         debug_log_initialized = true;
     }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -106,19 +106,18 @@ void init_debug_log()
     std::lock_guard<std::mutex> lock(log_init_mutex);
     if (!debug_log_initialized)
     {
-        std::string error_message;
-        auto log_level = get_env_variabe_no_log(ENV_AZDCAP_DEBUG_LOG, error_message);
-        if (!log_level.empty() && error_message.empty())
+        auto log_level = get_env_variable_no_log(ENV_AZDCAP_DEBUG_LOG);
+        if (!log_level.first.empty() && log_level.second.empty())
         {
-            enable_debug_logging(log_level);
+            enable_debug_logging(log_level.first);
         }
 
-        if (!error_message.empty())
+        if (!log_level.second.empty())
         {
             printf(
                 "Azure Quote Provider: libdcap_quoteprov.so [%s]: %s\n",
                 log_level_string(SGX_QL_LOG_ERROR).c_str(),
-                error_message.c_str());
+                log_level.second.c_str());
         }
         debug_log_initialized = true;
     }


### PR DESCRIPTION
This PR fixes a crash which would occur if neither the logging callback nor the azure dcap specific environment variable is set and adds a test for this condition

This was tested against Windows Server 2016 and Ubuntu 16 