### PR TITLE
Unifying HTTP error handling on Windows VS Linux

### DIFF
--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -427,11 +427,9 @@ void RunQuoteProviderTests(bool caching_enabled = false)
             CURL_TOLERANCE);
 
         constexpr int NUMBER_VERIFICATION_CURL_CALLS = 4;
-        constexpr int PERMISSION_CHECK_TEST_TOLERANCE =
-            CURL_TOLERANCE + CURL_FILESYSTEM_TOLERANCE;
         assert(
             duration_local_verification <
-            (NUMBER_VERIFICATION_CURL_CALLS * PERMISSION_CHECK_TEST_TOLERANCE));
+            (NUMBER_VERIFICATION_CURL_CALLS * (CURL_TOLERANCE + CURL_FILESYSTEM_TOLERANCE)));
     }
 }
 

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -381,7 +381,7 @@ constexpr auto CURL_TOLERANCE = 0.002;
 constexpr auto CURL_FILESYSTEM_TOLERANCE = 0;
 #else
 constexpr auto CURL_TOLERANCE = 0.04;
-constexpr auto CURL_FILESYSTEM_TOLERANCE = 0.1;
+constexpr auto CURL_FILESYSTEM_TOLERANCE = 0.025;
 #endif
 
 static inline float MeasureFunction(measured_function_t func)
@@ -430,7 +430,7 @@ void RunQuoteProviderTests(bool caching_enabled = false)
         assert(
             duration_local_verification <
             (NUMBER_VERIFICATION_CURL_CALLS * CURL_TOLERANCE) +
-                CURL_FILESYSTEM_TOLERANCE);
+               (NUMBER_VERIFICATION_CURL_CALLS * CURL_FILESYSTEM_TOLERANCE));
     }
 }
 

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -427,10 +427,11 @@ void RunQuoteProviderTests(bool caching_enabled = false)
             CURL_TOLERANCE);
 
         constexpr int NUMBER_VERIFICATION_CURL_CALLS = 4;
+        constexpr int PERMISSION_CHECK_TEST_TOLERANCE =
+            CURL_TOLERANCE + CURL_FILESYSTEM_TOLERANCE;
         assert(
             duration_local_verification <
-            (NUMBER_VERIFICATION_CURL_CALLS * CURL_TOLERANCE) +
-               (NUMBER_VERIFICATION_CURL_CALLS * CURL_FILESYSTEM_TOLERANCE));
+            (NUMBER_VERIFICATION_CURL_CALLS * PERMISSION_CHECK_TEST_TOLERANCE));
     }
 }
 

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -378,8 +378,10 @@ static void GetRootCACrlTest()
 // 2) The windows console is synchronous and quite slow relative to the linux console.
 #if defined __LINUX__
 constexpr auto CURL_TOLERANCE = 0.002;
+constexpr auto CURL_FILESYSTEM_TOLERANCE = 0;
 #else
 constexpr auto CURL_TOLERANCE = 0.04;
+constexpr auto CURL_FILESYSTEM_TOLERANCE = 0.1;
 #endif
 
 static inline float MeasureFunction(measured_function_t func)
@@ -427,7 +429,8 @@ void RunQuoteProviderTests(bool caching_enabled = false)
         constexpr int NUMBER_VERIFICATION_CURL_CALLS = 4;
         assert(
             duration_local_verification <
-            NUMBER_VERIFICATION_CURL_CALLS * CURL_TOLERANCE);
+            (NUMBER_VERIFICATION_CURL_CALLS * CURL_TOLERANCE) +
+                CURL_FILESYSTEM_TOLERANCE);
     }
 }
 
@@ -550,7 +553,7 @@ void make_folder(std::string foldername, permission_type_t permission)
 {
 #if defined __LINUX__
     assert(0 == mkdir(foldername.c_str(), permission));
-#else 
+#else
     assert(CreateDirectoryA(foldername.c_str(), NULL));
     set_access(foldername, permission);
 #endif

--- a/src/UnitTests/test_quote_prov.cpp
+++ b/src/UnitTests/test_quote_prov.cpp
@@ -420,8 +420,10 @@ void RunQuoteProviderTests(bool caching_enabled = false)
         // Ensure that there is a signficiant enough difference between the cert
         // fetch to the end point and cert fetch to local cache and that local
         // cache call is fast enough
+        constexpr auto PERMISSION_CHECK_TEST_TOLERANCE =
+            CURL_TOLERANCE + CURL_FILESYSTEM_TOLERANCE;
         assert(fabs(duration_curl_cert - duration_local_cert) > CURL_TOLERANCE);
-        assert(duration_local_cert < CURL_TOLERANCE);
+        assert(duration_local_cert < (CURL_TOLERANCE + PERMISSION_CHECK_TEST_TOLERANCE));
         assert(
             fabs(duration_curl_verification - duration_local_verification) >
             CURL_TOLERANCE);
@@ -429,7 +431,7 @@ void RunQuoteProviderTests(bool caching_enabled = false)
         constexpr int NUMBER_VERIFICATION_CURL_CALLS = 4;
         assert(
             duration_local_verification <
-            (NUMBER_VERIFICATION_CURL_CALLS * (CURL_TOLERANCE + CURL_FILESYSTEM_TOLERANCE)));
+            (NUMBER_VERIFICATION_CURL_CALLS * PERMISSION_CHECK_TEST_TOLERANCE));
     }
 }
 


### PR DESCRIPTION
** Note**
Re-opening PR for new build  system

**Problem**
There were a couple problems that were addressed as a part of this PR.

We found that 400+ HTTP errors weren't handled the same as far as logging and fast failure goes on Windows Vs. Linux thus causing log messages like TCB info missing and header info missing to be logged before throwing an exception.
The DCAP client tests were failing as a result of a Tolerance check that wasn't being met when requesting information from the filesystem.

**What was done**

A helper function was added to get the response code from the WinHTTP headers after a HTTP request was performed.
The perform() function in the curl_easy class was modified to now log the HTTP error the same as is done in Linux and we trigger a failure directly from this section of the code path to mimic the behavior found via testing in Linux and help with future debugging.
A const value of 0.015 was added to add tolerance to the duration of duration_local_verification when running permissions check tests. We found these to be consistently failing when using the local cache only as a result of a longer duration of around ~.05-.07 hence the buffer of 0.1 was added.

**Testing**
As per the normal testing procedures it was tested as follows:

This was tested locally against a local built PCK service both in windows and in WSL ubuntu.
Tested on both a Win19ACCVM and an Ubuntu 18 ACC VM.
a) Tested against the PCK Caching service Test Cluster Endpoint
b) Tested against the PCK Caching service Global Endpoint