### PR TITLE
V3 changes, coffelake v3, icx v3, e2etesting feature branch

### DIFF
--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -75,7 +75,7 @@ typedef quote3_error_t (*sgx_ql_get_qve_identity_t)(
     uint32_t* p_qve_identity_issuer_chain_size);
 
 typedef quote3_error_t (*sgx_ql_get_root_ca_crl_t)(
-    bool icx_test,
+    bool is_sbx,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size);
 
@@ -143,6 +143,8 @@ static sgx_isv_svn_t pcesvn = 6;
 
 static sgx_ql_pck_cert_id_t id = {qe_id, sizeof(qe_id), &cpusvn, &pcesvn, 0};
 
+// TODO: (ICX) Replace this platform data once we're pulling icx from
+// live
 static uint8_t icx_qe_id[16] = {
     0xed,
     0x1e,
@@ -719,31 +721,31 @@ boolean RunQuoteProviderTestsICXV3(bool caching_enabled = false)
 {
     local_cache_clear();
 
-    /*auto duration_curl_cert = MeasureFunction(GetCertsTestICXV3);
+    auto duration_curl_cert = MeasureFunction(GetCertsTestICXV3);
     GetCrlTestICXV3();
 
     auto duration_curl_verification =
-        MeasureFunction(GetVerificationCollateralTestICXV3);*/
+        MeasureFunction(GetVerificationCollateralTestICXV3);
 
+    // TODO: (ICX) This test can be modified back once we have icx prod cluster data to test with
     GetRootCACrlICXTest();
-    /*
     //
     // Second pass: Ensure that we ONLY get data from the cache
     //
     auto duration_local_cert = MeasureFunction(GetCertsTestICXV3);
 
-    GetCrlTest();
-    GetRootCACrlTest();
+    GetCrlTestICXV3();
+    GetRootCACrlICXTest();
 
     auto duration_local_verification =
-        MeasureFunction(GetVerificationCollateralTest);
+        MeasureFunction(GetVerificationCollateralTestICXV3);
 
     VerifyDurationChecks(
         duration_local_cert,
         duration_local_verification,
         duration_curl_cert,
         duration_curl_verification,
-        caching_enabled);*/
+        caching_enabled);
     return true;
 }
 

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -75,6 +75,7 @@ typedef quote3_error_t (*sgx_ql_get_qve_identity_t)(
     uint32_t* p_qve_identity_issuer_chain_size);
 
 typedef quote3_error_t (*sgx_ql_get_root_ca_crl_t)(
+    bool icx_test,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size);
 
@@ -599,7 +600,26 @@ static void GetRootCACrlTest()
     char* root_ca_crl = nullptr;
     uint16_t root_ca_crl_size;
     quote3_error_t result =
-        sgx_ql_get_root_ca_crl(&root_ca_crl, &root_ca_crl_size);
+        sgx_ql_get_root_ca_crl(false, &root_ca_crl, &root_ca_crl_size);
+    ASSERT_TRUE(SGX_QL_SUCCESS == result);
+    ASSERT_TRUE(root_ca_crl != nullptr);
+    ASSERT_TRUE(root_ca_crl_size > 0);
+    ASSERT_TRUE(root_ca_crl[root_ca_crl_size - 1] == '\0');
+
+    sgx_ql_free_root_ca_crl(root_ca_crl);
+
+    TEST_SUCCESS = true;
+    ASSERT_TRUE(TEST_SUCCESS);
+}
+
+static void GetRootCACrlICXTest()
+{
+    boolean TEST_SUCCESS = false;
+
+    char* root_ca_crl = nullptr;
+    uint16_t root_ca_crl_size;
+    quote3_error_t result =
+        sgx_ql_get_root_ca_crl(true, &root_ca_crl, &root_ca_crl_size);
     ASSERT_TRUE(SGX_QL_SUCCESS == result);
     ASSERT_TRUE(root_ca_crl != nullptr);
     ASSERT_TRUE(root_ca_crl_size > 0);
@@ -699,14 +719,14 @@ boolean RunQuoteProviderTestsICXV3(bool caching_enabled = false)
 {
     local_cache_clear();
 
-    auto duration_curl_cert = MeasureFunction(GetCertsTestICXV3);
+    /*auto duration_curl_cert = MeasureFunction(GetCertsTestICXV3);
     GetCrlTestICXV3();
 
     auto duration_curl_verification =
-        MeasureFunction(GetVerificationCollateralTestICXV3);
+        MeasureFunction(GetVerificationCollateralTestICXV3);*/
 
-    GetRootCACrlTest();
-    
+    GetRootCACrlICXTest();
+    /*
     //
     // Second pass: Ensure that we ONLY get data from the cache
     //
@@ -723,7 +743,7 @@ boolean RunQuoteProviderTestsICXV3(bool caching_enabled = false)
         duration_local_verification,
         duration_curl_cert,
         duration_curl_verification,
-        caching_enabled);
+        caching_enabled);*/
     return true;
 }
 

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -75,7 +75,6 @@ typedef quote3_error_t (*sgx_ql_get_qve_identity_t)(
     uint32_t* p_qve_identity_issuer_chain_size);
 
 typedef quote3_error_t (*sgx_ql_get_root_ca_crl_t)(
-    bool is_sbx,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size);
 
@@ -602,7 +601,7 @@ static void GetRootCACrlTest()
     char* root_ca_crl = nullptr;
     uint16_t root_ca_crl_size;
     quote3_error_t result =
-        sgx_ql_get_root_ca_crl(false, &root_ca_crl, &root_ca_crl_size);
+        sgx_ql_get_root_ca_crl(&root_ca_crl, &root_ca_crl_size);
     ASSERT_TRUE(SGX_QL_SUCCESS == result);
     ASSERT_TRUE(root_ca_crl != nullptr);
     ASSERT_TRUE(root_ca_crl_size > 0);
@@ -621,7 +620,7 @@ static void GetRootCACrlICXTest()
     char* root_ca_crl = nullptr;
     uint16_t root_ca_crl_size;
     quote3_error_t result =
-        sgx_ql_get_root_ca_crl(true, &root_ca_crl, &root_ca_crl_size);
+        sgx_ql_get_root_ca_crl(&root_ca_crl, &root_ca_crl_size);
     ASSERT_TRUE(SGX_QL_SUCCESS == result);
     ASSERT_TRUE(root_ca_crl != nullptr);
     ASSERT_TRUE(root_ca_crl_size > 0);
@@ -958,7 +957,7 @@ void SetupEnvironment(std::string version)
 #if defined __LINUX__
     setenv(
         "AZDCAP_BASE_CERT_URL",
-        "https://americas.test.acccache.azure.net/sgx/certificates",
+        "https://global.acccache.azure.net/sgx/certificates",
         1);
     setenv("AZDCAP_CLIENT_ID", "AzureDCAPTestsLinux", 1);
     if (!version.empty())
@@ -974,10 +973,17 @@ void SetupEnvironment(std::string version)
     }
     EXPECT_TRUE(SetEnvironmentVariableA(
         "AZDCAP_BASE_CERT_URL",
-        "https://americas.test.acccache.azure.net/sgx/certificates"));
+        "https://global.acccache.azure.net/sgx/certificates"));
     EXPECT_TRUE(
         SetEnvironmentVariableA("AZDCAP_CLIENT_ID", "AzureDCAPTestsWindows"));
 #endif
+    // TODO: (ICX) Remove when we move icx to live and prod
+    if (!version.empty() && version.compare("v3") == 0)
+    {
+        EXPECT_TRUE(SetEnvironmentVariableA(
+            "AZDCAP_BASE_CERT_URL",
+            "https://americas.test.acccache.azure.net/sgx/certificates"));
+    }
 }
 
 TEST(testQuoteProv, quoteProviderTestsDataFromService)

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -395,8 +395,6 @@ static void GetCrlTest()
 //
 static void GetCrlTestICXV3()
 {
-    boolean TEST_SUCCESS = false;
-
     // This is the CRL DP used by Intel for leaf certs
     static const char* TEST_CRL_URL =
         "https://sbx.api.trustedservices.intel.com/sgx/certification/v3/"

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -963,6 +963,13 @@ void SetupEnvironment(std::string version)
     if (!version.empty())
     {
         setenv("AZDCAP_COLLATERAL_VERSION", version.c_str(), 1);
+        if (version.c_str() == "v3")
+        {
+            setenv(
+                "AZDCAP_BASE_CERT_URL",
+                "https://americas.test.acccache.azure.net/sgx/certificates",
+                1);
+        }
     }
 #else
     std::stringstream version_var;
@@ -976,7 +983,6 @@ void SetupEnvironment(std::string version)
         "https://global.acccache.azure.net/sgx/certificates"));
     EXPECT_TRUE(
         SetEnvironmentVariableA("AZDCAP_CLIENT_ID", "AzureDCAPTestsWindows"));
-#endif
     // TODO: (ICX) Remove when we move icx to live and prod
     if (!version.empty() && version.compare("v3") == 0)
     {
@@ -984,6 +990,7 @@ void SetupEnvironment(std::string version)
             "AZDCAP_BASE_CERT_URL",
             "https://americas.test.acccache.azure.net/sgx/certificates"));
     }
+#endif
 }
 
 TEST(testQuoteProv, quoteProviderTestsDataFromService)

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -963,7 +963,7 @@ void SetupEnvironment(std::string version)
     if (!version.empty())
     {
         setenv("AZDCAP_COLLATERAL_VERSION", version.c_str(), 1);
-        if (strcmp(version.c_str(),"v3") == 0)
+        if (version == "v3")
         {
             setenv(
                 "AZDCAP_BASE_CERT_URL",

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -1026,7 +1026,7 @@ TEST(testQuoteProv, quoteProviderTestsV3DataFromService)
     // Get the data from the service
     //
     SetupEnvironment("v3");
-  //  ASSERT_TRUE(RunQuoteProviderTests());
+    ASSERT_TRUE(RunQuoteProviderTests());
     ASSERT_TRUE(RunQuoteProviderTestsICXV3());
     ASSERT_TRUE(GetQveIdentityTest());
 

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -950,6 +950,7 @@ TEST(testQuoteProv, quoteProviderTestsV3DataFromService)
     // Get the data from the service
     //
     SetupEnvironment("v3");
+    ASSERT_TRUE(RunQuoteProviderTests());
     ASSERT_TRUE(RunQuoteProviderTestsICXV3());
     ASSERT_TRUE(GetQveIdentityTest());
 

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -963,7 +963,7 @@ void SetupEnvironment(std::string version)
     if (!version.empty())
     {
         setenv("AZDCAP_COLLATERAL_VERSION", version.c_str(), 1);
-        if (version.c_str() == "v3")
+        if (strcmp(version.c_str(),"v3") == 0)
         {
             setenv(
                 "AZDCAP_BASE_CERT_URL",

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1465,7 +1465,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         if (strcmp(CRL_CA_PLATFORM, pck_ca) == 0)
         {
             requested_ca = PLATFORM_CRL_NAME;
-            root_crl_name = SBX_ROOT_CRL_NAME;
+           // root_crl_name = SBX_ROOT_CRL_NAME;
         }
 
         if (requested_ca.empty())

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -69,8 +69,8 @@ static char CRL_CA_PROCESSOR[] = "processor";
 static char CRL_CA_PLATFORM[] = "platform";
 static char ROOT_CRL_NAME[] =
     "https%3a%2f%2fcertificates.trustedservices.intel.com%2fintelsgxrootca.crl";
-static char SBX_ROOT_CRL_NAME[] =
-    "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
+//static char SBX_ROOT_CRL_NAME[] =
+//    "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
 static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform%26encoding%3dpem";

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -110,11 +110,12 @@ static std::string get_collateral_version()
     else
     {
         if (!collateral_version.compare("v1") &&
-            !collateral_version.compare("v2"))
+            !collateral_version.compare("v2") &&
+            !collateral_version.compare("v3"))
         {
             log(SGX_QL_LOG_ERROR,
                 "Value specified in environment variable '%s' is invalid. "
-                "Acceptable values are empty, v1, or v2",
+                "Acceptable values are empty, v1, or v2 or v3",
                 collateral_version.c_str(),
                 MAX_ENV_VAR_LENGTH);
 

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1757,7 +1757,7 @@ extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
 
         std::string root_ca_crl_url =
             build_pck_crl_url(ROOT_CRL_NAME, API_VERSION);
-        if (icx_test = true)
+        if (icx_test == true)
         {
             std::string root_ca_crl_url =
                 build_pck_crl_url(SBX_ROOT_CRL_NAME, API_VERSION);

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -71,6 +71,7 @@ static char ROOT_CRL_NAME[] =
     "https%3a%2f%2fcertificates.trustedservices.intel.com%2fintelsgxrootca.crl";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
+static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform";
 
 static const string CACHE_CONTROL_MAX_AGE = "max-age=";
 
@@ -736,7 +737,7 @@ static std::string build_enclave_id_url(
     }
 
     // If QVE and V1 is specified, don't create a URL
-    if (qve && version != "v2")
+    if (qve && version == "v1")
     {
         return "";
     }
@@ -1459,8 +1460,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
 
         if (strcmp(CRL_CA_PLATFORM, pck_ca) == 0)
         {
-            log(SGX_QL_LOG_ERROR, "Platform CA CRL is not supported");
-            return SGX_QL_ERROR_INVALID_PARAMETER;
+            requested_ca = PLATFORM_CRL_NAME;
         }
 
         if (requested_ca.empty())

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -69,6 +69,8 @@ static char CRL_CA_PROCESSOR[] = "processor";
 static char CRL_CA_PLATFORM[] = "platform";
 static char ROOT_CRL_NAME[] =
     "https%3a%2f%2fcertificates.trustedservices.intel.com%2fintelsgxrootca.crl";
+static char SBX_ROOT_CRL_NAME[] =
+    "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
 static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform%26encoding%3dpem";
@@ -1454,6 +1456,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         }
 
         std::string requested_ca;
+        std::string root_crl_name = ROOT_CRL_NAME;
         if (strcmp(CRL_CA_PROCESSOR, pck_ca) == 0)
         {
             requested_ca = PROCESSOR_CRL_NAME;
@@ -1462,6 +1465,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         if (strcmp(CRL_CA_PLATFORM, pck_ca) == 0)
         {
             requested_ca = PLATFORM_CRL_NAME;
+            root_crl_name = SBX_ROOT_CRL_NAME;
         }
 
         if (requested_ca.empty())

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -69,8 +69,8 @@ static char CRL_CA_PROCESSOR[] = "processor";
 static char CRL_CA_PLATFORM[] = "platform";
 static char ROOT_CRL_NAME[] =
     "https%3a%2f%2fcertificates.trustedservices.intel.com%2fintelsgxrootca.crl";
-//static char SBX_ROOT_CRL_NAME[] =
-//    "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
+static char SBX_ROOT_CRL_NAME[] =
+    "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
 static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform%26encoding%3dpem";
@@ -1465,7 +1465,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         if (strcmp(CRL_CA_PLATFORM, pck_ca) == 0)
         {
             requested_ca = PLATFORM_CRL_NAME;
-           // root_crl_name = SBX_ROOT_CRL_NAME;
+            root_crl_name = SBX_ROOT_CRL_NAME;
         }
 
         if (requested_ca.empty())
@@ -1734,6 +1734,7 @@ extern "C" quote3_error_t sgx_ql_get_qve_identity(
 }
 
 extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
+    bool icx_test,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size)
 {
@@ -1756,6 +1757,11 @@ extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
 
         std::string root_ca_crl_url =
             build_pck_crl_url(ROOT_CRL_NAME, API_VERSION);
+        if (icx_test = true)
+        {
+            std::string root_ca_crl_url =
+                build_pck_crl_url(SBX_ROOT_CRL_NAME, API_VERSION);
+        }
         std::vector<uint8_t> root_ca_crl;
         std::string root_ca_chain;
 

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1456,7 +1456,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         }
 
         std::string requested_ca;
-        std::string root_crl_name = SBX_ROOT_CRL_NAME;
+        std::string root_crl_name = ROOT_CRL_NAME;
         if (strcmp(CRL_CA_PROCESSOR, pck_ca) == 0)
         {
             requested_ca = PROCESSOR_CRL_NAME;
@@ -1506,7 +1506,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
 
         // Get Root CA CRL
         std::string root_ca_crl_url =
-            build_pck_crl_url(ROOT_CRL_NAME, API_VERSION);
+            build_pck_crl_url(root_crl_name, API_VERSION);
         operation_result = get_collateral(
             CollateralTypes::PckRootCrl,
             root_ca_crl_url,

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -73,6 +73,8 @@ static char SBX_ROOT_CRL_NAME[] =
     "https%3a%2f%2fsbx-certificates.trustedservices.intel.com%2fintelsgxrootca.der";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
+
+// TODO: (ICX) Replace this platform CRL distinction once we're pulling icx from live
 static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform%26encoding%3dpem";
 
 static const string CACHE_CONTROL_MAX_AGE = "max-age=";
@@ -1465,6 +1467,8 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         if (strcmp(CRL_CA_PLATFORM, pck_ca) == 0)
         {
             requested_ca = PLATFORM_CRL_NAME;
+
+            // TODO: (ICX) Test and remove this root distinction once we're pulling icx from live
             root_crl_name = SBX_ROOT_CRL_NAME;
         }
 
@@ -1734,7 +1738,7 @@ extern "C" quote3_error_t sgx_ql_get_qve_identity(
 }
 
 extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
-    bool icx_test,
+    bool is_sbx,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size)
 {
@@ -1757,7 +1761,7 @@ extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
 
         std::string root_ca_crl_url =
             build_pck_crl_url(ROOT_CRL_NAME, API_VERSION);
-        if (icx_test == true)
+        if (is_sbx == true)
         {
             std::string root_ca_crl_url =
                 build_pck_crl_url(SBX_ROOT_CRL_NAME, API_VERSION);

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1738,7 +1738,6 @@ extern "C" quote3_error_t sgx_ql_get_qve_identity(
 }
 
 extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
-    bool is_sbx,
     char** pp_root_ca_crl,
     uint16_t* p_root_ca_crl_size)
 {
@@ -1761,11 +1760,6 @@ extern "C" quote3_error_t sgx_ql_get_root_ca_crl(
 
         std::string root_ca_crl_url =
             build_pck_crl_url(ROOT_CRL_NAME, API_VERSION);
-        if (is_sbx == true)
-        {
-            std::string root_ca_crl_url =
-                build_pck_crl_url(SBX_ROOT_CRL_NAME, API_VERSION);
-        }
         std::vector<uint8_t> root_ca_crl;
         std::string root_ca_chain;
 

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -71,7 +71,7 @@ static char ROOT_CRL_NAME[] =
     "https%3a%2f%2fcertificates.trustedservices.intel.com%2fintelsgxrootca.crl";
 static char PROCESSOR_CRL_NAME[] = "https%3a%2f%2fcertificates.trustedservices."
                                    "intel.com%2fintelsgxpckprocessor.crl";
-static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform";
+static char PLATFORM_CRL_NAME[] = "https%3a%2f%2fsbx.api.trustedservices.intel.com%2fsgx%2fcertification%2fv3%2fpckcrl%3fca%3dplatform%26encoding%3dpem";
 
 static const string CACHE_CONTROL_MAX_AGE = "max-age=";
 

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1456,7 +1456,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_verification_collateral(
         }
 
         std::string requested_ca;
-        std::string root_crl_name = ROOT_CRL_NAME;
+        std::string root_crl_name = SBX_ROOT_CRL_NAME;
         if (strcmp(CRL_CA_PROCESSOR, pck_ca) == 0)
         {
             requested_ca = PROCESSOR_CRL_NAME;


### PR DESCRIPTION
Minor changes to enable v3 for icx and coffelake.

- Testing added to test v3 flow for coffeelake and icelake in a v3 environment.
- Temporary support for sbx endpoint collateral (Detailed Description)
           -  Currently all icelake collateral is from the SBX endpoint thus the root CA its signed by is from the sbx endpoint
           - Testing had to involve placing the sbx collateral in the pck cache qe identity, and tcb info as well as make the root CA Crl 
           - available to pass end to end tests for v3 icelake with oesdk.
- Once we have the prod icelake cluster we can remove this support and default to the prod endpoint with prod test hardware.
