### PR TITLE
Calling into thim agent to get collateral.

### DIFF
--- a/src/Linux/curl_easy.h
+++ b/src/Linux/curl_easy.h
@@ -36,7 +36,10 @@ class curl_easy
         char function[128]{};
     };
 
-    static std::unique_ptr<curl_easy> create(const std::string& url, const std::string* const p_body);
+    static std::unique_ptr<curl_easy> create(
+        const std::string& url,
+        const std::string* const p_body,
+        LPCWSTR httpVerb = L"GET");
 
     ~curl_easy();
 

--- a/src/UnitTest/test_quote_prov.cpp
+++ b/src/UnitTest/test_quote_prov.cpp
@@ -458,7 +458,7 @@ static void GetCrlTest()
 {
     // This is the CRL DP used by Intel for leaf certs
     static const char* TEST_CRL_URL =
-        "https://api.trustedservices.intel.com/sgx/certification/v1/"
+        "https://api.trustedservices.intel.com/sgx/certification/v3/"
         "pckcrl?ca=processor";
 
     sgx_ql_get_revocation_info_params_t params = {
@@ -927,7 +927,11 @@ void SetupEnvironment(std::string version)
 #if defined __LINUX__
     setenv(
         "AZDCAP_BASE_CERT_URL",
-        "https://global.acccache.azure.net/sgx/certificates",
+        "https://global.acccache.azure.net/sgx/certificates/",
+        1);
+    setenv(
+        "AZDCAP_THIM_AGENT_URL",
+        "http://169.254.169.254/metadata/THIM/sgx/getCerts?",
         1);
     setenv("AZDCAP_CLIENT_ID", "AzureDCAPTestsLinux", 1);
     if (!version.empty())
@@ -943,7 +947,10 @@ void SetupEnvironment(std::string version)
     }
     EXPECT_TRUE(SetEnvironmentVariableA(
         "AZDCAP_BASE_CERT_URL",
-        "https://global.acccache.azure.net/sgx/certificates"));
+        "https://global.acccache.azure.net/sgx/certificates/"));
+    EXPECT_TRUE(SetEnvironmentVariableA(
+        "AZDCAP_THIM_AGENT_URL",
+        "http://169.254.169.254/metadata/THIM/sgx/getCerts?"));
     EXPECT_TRUE(
         SetEnvironmentVariableA("AZDCAP_CLIENT_ID", "AzureDCAPTestsWindows"));
 #endif
@@ -997,6 +1004,7 @@ TEST(testQuoteProv, quoteProviderTestsV2DataFromService)
     // Get the data from the service
     //
     SetupEnvironment("v2");
+
     ASSERT_TRUE(RunQuoteProviderTests());
     ASSERT_TRUE(GetQveIdentityTest());
 

--- a/src/Windows/curl_easy.cpp
+++ b/src/Windows/curl_easy.cpp
@@ -17,8 +17,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
 ///////////////////////////////////////////////////////////////////////////////
-static constexpr int maximum_retries = 5;
-static constexpr int initial_retry_delay_ms = 20;
+static constexpr int maximum_retries = 3;
+static constexpr int initial_retry_delay_ms = 2000;
 static constexpr WCHAR content_type_header[] =
     L"Content-Type: application/json";
 
@@ -128,7 +128,8 @@ std::wstring UnicodeStringFromUtf8String(_In_ const std::string& ansiString)
 ///////////////////////////////////////////////////////////////////////////////
 std::unique_ptr<curl_easy> curl_easy::create(
     const std::string& url,
-    const std::string* const p_body)
+    const std::string* const p_body,
+    LPCWSTR httpVerb)
 {
     struct make_unique_enabler : public curl_easy
     {
@@ -191,7 +192,7 @@ std::unique_ptr<curl_easy> curl_easy::create(
 
     curl->request.reset(WinHttpOpenRequest(
         curl->connectionHandle.get(),
-        L"GET",
+        httpVerb,
         urlToRetrieve.c_str(),
         nullptr,
         WINHTTP_NO_REFERER,

--- a/src/Windows/curl_easy.h
+++ b/src/Windows/curl_easy.h
@@ -39,7 +39,8 @@ class curl_easy
     };
     static std::unique_ptr<curl_easy> create(
         const std::string& url,
-        const std::string* const p_body);
+        const std::string* const p_body,
+        LPCWSTR httpVerb = L"GET");
 
     ~curl_easy();
 

--- a/src/dcap_provider.h
+++ b/src/dcap_provider.h
@@ -6,6 +6,9 @@
 #define PLATFORM_QUOTE_PROVIDER_H
 
 #include <stdint.h>
+#include <sstream>
+
+using namespace std;
 
 /*****************************************************************************
  * Data types and interfaces for getting platform revocation info. This
@@ -83,6 +86,15 @@ typedef sgx_plat_error_t (*sgx_get_qe_identity_info_t)(
 
 typedef void (*sgx_free_qe_identity_info_t)(
     sgx_qe_identity_info_t* p_qe_identity_info);
+
+/*****************************************************************************
+ * Structure to pass THIM agent and THIM service URL
+ ****************************************************************************/
+
+typedef struct _collateral_fetch_url {
+    std::stringstream thim_agent_url; // URL to fetch collateral from the agent
+    std::stringstream thim_service_url; // URL to fetch collateral from the service
+} collateral_fetch_url;
 
 /*****************************************************************************
  * Data types and interfaces for configuration the platform quote provider

--- a/src/environment.h
+++ b/src/environment.h
@@ -11,6 +11,7 @@
 //  modify or override these values as they can cause regressions in
 //  caching service behavior.
 #define ENV_AZDCAP_BASE_URL "AZDCAP_BASE_CERT_URL"
+#define ENV_AZDCAP_THIM_AGENT_URL "AZDCAP_THIM_AGENT_URL"
 #define ENV_AZDCAP_CLIENT_ID "AZDCAP_CLIENT_ID"
 #define ENV_AZDCAP_COLLATERAL_VER "AZDCAP_COLLATERAL_VERSION"
 #define ENV_AZDCAP_DEBUG_LOG "AZDCAP_DEBUG_LOG_LEVEL"


### PR DESCRIPTION
1. Adding call to thim agent for Get cert collateral.
2. Updating the API call to THIM service to use the new noauth API introduced in the service.

Testing:
1. Unit tests pass on Windows. 