### PR TITLE
Updating the return code for windows in case curl errors out and adding test cases for the same.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -120,6 +120,7 @@ def ACCTestOeRelease(String label, String version) {
                         sudo dpkg -i ${WORKSPACE}/src/az-dcap-client_*_amd64.deb
                         sudo apt-get update
                         sudo apt-get install -y open-enclave
+                        /opt/openenclave/bin/oeapkman root
                         . /opt/openenclave/share/openenclave/openenclaverc
                         cp -r /opt/openenclave/share/openenclave/samples/ ~/samples
                         for DIR in \$(find ~/samples/* -maxdepth 0 -type d); do
@@ -135,7 +136,7 @@ def ACCTestOeRelease(String label, String version) {
                 else
                 {
                     dcap.ContainerRun("${DOCKER_REGISTRY}/dcapdockerciregistry-ubuntu${version}:latest", "clang-10", task, "--cap-add=SYS_PTRACE --device /dev/sgx:/dev/sgx --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket")
-                } 			
+                }
 			}
         }
     }

--- a/.jenkins/JenkinsfileTestLinuxRelease
+++ b/.jenkins/JenkinsfileTestLinuxRelease
@@ -87,6 +87,7 @@ def ACCTestOeRelease(String label, String version) {
                     sudo apt-get upgrade -y az-dcap-client
                     sudo apt-get update
                     sudo apt-get install -y open-enclave
+                    /opt/openenclave/bin/oeapkman root
                     . /opt/openenclave/share/openenclave/openenclaverc
                     cp -r /opt/openenclave/share/openenclave/samples/ ~/samples
                     for DIR in \$(find ~/samples/* -maxdepth 0 -type d); do

--- a/src/Linux/curl_easy.h
+++ b/src/Linux/curl_easy.h
@@ -15,7 +15,6 @@
 #include <vector>
 #include <curl/curl.h>
 
-const uint32_t WINHTTP_ERROR_BASE = 12000;
 //
 // RAII wrapper around Curl to make resource management exception-safe. This
 // class also converts

--- a/src/Linux/curl_easy.h
+++ b/src/Linux/curl_easy.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <curl/curl.h>
 
+const uint32_t WINHTTP_ERROR_BASE = 12000;
 //
 // RAII wrapper around Curl to make resource management exception-safe. This
 // class also converts
@@ -64,6 +65,7 @@ class curl_easy
         char* ptr,
         size_t size,
         size_t nmemb,
+        void* user_data);
         void* user_data);
 
 #pragma warning( \

--- a/src/Linux/curl_easy.h
+++ b/src/Linux/curl_easy.h
@@ -66,7 +66,6 @@ class curl_easy
         size_t size,
         size_t nmemb,
         void* user_data);
-        void* user_data);
 
 #pragma warning( \
     suppress : 25033 25057) // CURL defines input buffers as non-const

--- a/src/Windows/curl_easy.cpp
+++ b/src/Windows/curl_easy.cpp
@@ -309,8 +309,7 @@ void curl_easy::perform() const
         }
 
         DWORD response_code = get_response_code();
-        if (response_code >= HTTP_STATUS_BAD_REQUEST &&
-            response_code <= HTTP_STATUS_SERVER_ERROR)
+        if (response_code >= HTTP_STATUS_BAD_REQUEST)
         {
             log(SGX_QL_LOG_INFO,
                 "HTTP Error (%d) on curl->perform() request",

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1255,7 +1255,8 @@ static quote3_error_t get_collateral(
             "curl error thrown, error code: %x: %s",
             error.code,
             error.what());
-        return error.code == CURLE_HTTP_RETURNED_ERROR
+        return error.code == CURLE_HTTP_RETURNED_ERROR ||
+                       error.code == WINHTTP_ERROR_BASE
                    ? SGX_QL_NO_QUOTE_COLLATERAL_DATA
                    : SGX_QL_NETWORK_ERROR;
     }

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1255,10 +1255,15 @@ static quote3_error_t get_collateral(
             "curl error thrown, error code: %x: %s",
             error.code,
             error.what());
-        return error.code == CURLE_HTTP_RETURNED_ERROR ||
-                       error.code == WINHTTP_ERROR_BASE
+        #ifdef __LINUX__
+            return error.code == CURLE_HTTP_RETURNED_ERROR
                    ? SGX_QL_NO_QUOTE_COLLATERAL_DATA
                    : SGX_QL_NETWORK_ERROR;
+        #else
+            return error.code == WINHTTP_ERROR_BASE
+                   ? SGX_QL_NO_QUOTE_COLLATERAL_DATA
+                   : SGX_QL_NETWORK_ERROR;
+        #endif
     }
 }
 


### PR DESCRIPTION
The return code for HTTP error code in the range 400 to 500 is different on Windows and Linux. The PR is to make the return code consistent(i.e SGX_QL_NO_QUOTE_COLLATERAL_DATA") is returned if Azure DCAP encounters an HTTP error between 400 to 500 when talking to the remote Service. 