### PR TITLE
Ensure `fetch_reponse` always sets error value

### DIFF
--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1315,6 +1315,7 @@ bool fetch_response(
         log(SGX_QL_LOG_WARNING,
             "Runtime exception thrown, error: %s",
             error.what());
+        retval = SGX_QL_ERROR_UNEXPECTED;
     }
     catch (const curl_easy::error& error)
     {
@@ -1322,12 +1323,14 @@ bool fetch_response(
             "error thrown, error code: %x: %s",
             error.code,
             error.what());
+        retval = SGX_QL_NETWORK_ERROR;
     }
     catch (const std::exception& error)
     {
         log(SGX_QL_LOG_ERROR,
             "Unknown exception thrown, error: %s",
             error.what());
+        retval = SGX_QL_ERROR_UNEXPECTED;
     }
     return fetch_response;
 }


### PR DESCRIPTION
When `sgx_ql_get_quote_config` calls `fetch_response`, it [expects it (line 1400-1406)](https://github.com/microsoft/Azure-DCAP-Client/blob/master/src/dcap_provider.cpp#L1400-L1406) to set a `retval` (error value). This didn't happen in all cases causing it for example to return `SGX_QL_SUCCESS` even when a network failure prevented it to download artifacts.