### PR TITLE
Adding mariner to the build pipeline

### DIFF
--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,15 +49,15 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name "${{ inputs.commandName }}" --instance-view)'
+          echo 'result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name "${{ inputs.commandName }}" --instance-view)' >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash
       run: |
-          echo -e ${{steps.commandResult.outputs.result}} 
+          echo -e ${{env.result}} 
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 
-          if [[ "${{steps.commandResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+          if [[ "${{env.result}}" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
       
 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Show the output of the command
       shell: bash
       run: |
-          printf "${{ steps.commandResult.outputs.result }}"
+          bash -c "printf "${{ steps.commandResult.outputs.result }}""
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -27,8 +27,7 @@ runs:
             --name "${{ inputs.commandName }}" \
             --script "${{ inputs.script }} && echo 'DCAP_Build_Step_Successfully_Completed'"
 
-#   This action fails to execute when trying to run complex commands in windows
-#   Thus, it has been disabled for windows
+#    Due to failures related to escaping special characters through yaml, bash, powershell and cmd simultaneously, this action is currently disabled for windows.
 #    - name: Execute the command in windows
 #      if: ${{ env.os == 'windows' }}
 #      uses: azure/CLI@v1

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,8 +49,9 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          resultMessage=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)
-          echo "result=$resultMessage" >> $GITHUB_OUTPUT
+          echo 'FILE_TEXT<<EOF' >> $GITHUB_OUTPUT
+          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,17 +49,15 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo 'FILE_TEXT<<EOF' >> $GITHUB_OUTPUT
           echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash
       run: |
-          echo -e ${{env.result}} 
+          echo -e ${{steps.commandResult.outputs.result}} 
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 
-          if [[ "${{env.result}}" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+          if [[ "${{steps.commandResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
       
 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -57,6 +57,10 @@ runs:
       shell: bash
       run: |
           echo -e "${{ steps.commandResult.outputs.result }}" 
+          
+    - name: Verify the output of the command
+      shell: bash
+      run: |
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -24,6 +24,7 @@ runs:
           az vm run-command create \
             --resource-group $rgName \
             --vm-name $vmName \
+            --location ${{ matrix.location }} \
             --name "${{ inputs.commandName }}" \
             --script "${{ inputs.script }} && echo 'DCAP_Build_Step_Successfully_Completed'"
 
@@ -36,6 +37,7 @@ runs:
 #          az vm run-command create \
 #            --resource-group $rgName \
 #            --vm-name $vmName \
+#            --location ${{ matrix.location }} \
 #            --name "${{ inputs.commandName }}" \
 #            --script '${{ inputs.script }}
 #                      if($?){ 
@@ -47,7 +49,7 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "${{ inputs.commandName }}" --instance-view)'
+          echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name "${{ inputs.commandName }}" --instance-view)'
     
     - name: Show the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -22,7 +22,6 @@ runs:
       with:
         inlineScript: |
           az vm run-command create \
-            --debug \
             --resource-group $rgName \
             --vm-name $vmName \
             --location ${{ matrix.location }} \

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -44,22 +44,15 @@ runs:
 #                      Write-Host "DCAP_Build_Step_Successfully_Completed" 
 #                      Write-Host "Write a second line to get a line break after the success tag" 
 #                      }'
-            
-    - name: Get the result of the command
-      id: commandResult
-      shell: bash
-      run: |
-          echo "result<<EOF" >> $GITHUB_OUTPUT
-          echo "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
           
-    - name: Verify the output of the command
+    - name: Get the result of the command
       shell: bash
       run: |
-          echo -e "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)"
+          result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)
+          echo -e "$result"
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 
-          if [[ "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+          if [[ "$result" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
       
 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -52,14 +52,11 @@ runs:
           echo "result<<EOF" >> $GITHUB_OUTPUT
           echo "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-    
+          
     - name: Show the output of the command
       shell: bash
-      run: echo -e "${{ steps.commandResult.outputs.result }}"
-          
-    - name: Verify the output of the command
-      shell: bash
       run: |
+          printf "${{ steps.commandResult.outputs.result }}"
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Show the output of the command
       shell: bash
       run: |
-          bash -c "printf "${{ steps.commandResult.outputs.result }}""
+          # bash -c "printf "${{ steps.commandResult.outputs.result }}""
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,14 +49,14 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo 'FILE_TEXT<<EOF' >> $GITHUB_OUTPUT
-          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "result<<EOF" >> $GITHUB_OUTPUT
+          echo "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash
       run: |
-          echo -e ${{steps.commandResult.outputs.result}} 
+          echo -e "${{ steps.commandResult.outputs.result }}" 
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,7 +49,7 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo 'result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name "${{ inputs.commandName }}" --instance-view)' >> $GITHUB_OUTPUT
+          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name \"${{ inputs.commandName }}\" --instance-view)" >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -53,13 +53,13 @@ runs:
           echo "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           
-    - name: Show the output of the command
+    - name: Verify the output of the command
       shell: bash
       run: |
-          # bash -c "printf "${{ steps.commandResult.outputs.result }}""
+          echo -e "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)"
           # az vm run-command returns both the output of the commands executed AND the commands executed
           # For this reason we have to search for the success tag + a linebreak to know that the tag is in the output
           # If we searched only for the tag, we'd find it as part of the commands executed, even if the step failed and echo 'DCAP_Build_Step_Successfully_Completed' never executed 
-          if [[ "${{steps.commandResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+          if [[ "$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" == *"DCAP_Build_Step_Successfully_Completed\n"* ]]; then echo "Step successfully executed"; else exit 1; fi 
       
 

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,7 +49,7 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name \"${{ inputs.commandName }}\" --instance-view)" >> $GITHUB_OUTPUT
+          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -22,6 +22,7 @@ runs:
       with:
         inlineScript: |
           az vm run-command create \
+            --debug \
             --resource-group $rgName \
             --vm-name $vmName \
             --location ${{ matrix.location }} \

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,7 +49,9 @@ runs:
       id: commandResult
       shell: bash
       run: |
+          echo 'FILE_TEXT<<EOF' >> $GITHUB_OUTPUT
           echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -55,8 +55,7 @@ runs:
     
     - name: Show the output of the command
       shell: bash
-      run: |
-          ${{ steps.commandResult.outputs.result }}
+      run: echo ${{ steps.commandResult.outputs.result }}
           
     - name: Verify the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -55,7 +55,7 @@ runs:
     
     - name: Show the output of the command
       shell: bash
-      run: echo ${{ steps.commandResult.outputs.result }}
+      run: echo -e "${{ steps.commandResult.outputs.result }}"
           
     - name: Verify the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Show the output of the command
       shell: bash
       run: |
-          echo "${{ steps.commandResult.outputs.result }}" 
+          ${{ steps.commandResult.outputs.result }}
           
     - name: Verify the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Show the output of the command
       shell: bash
       run: |
-          echo -e "${{ steps.commandResult.outputs.result }}" 
+          echo "${{ steps.commandResult.outputs.result }}" 
           
     - name: Verify the output of the command
       shell: bash

--- a/.github/actions/actionAzVmRunCommand/action.yml
+++ b/.github/actions/actionAzVmRunCommand/action.yml
@@ -49,7 +49,8 @@ runs:
       id: commandResult
       shell: bash
       run: |
-          echo "result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)" >> $GITHUB_OUTPUT
+          resultMessage=$(az vm run-command show --resource-group $rgName --vm-name $vmName --location ${{ matrix.location }} --name ${{ inputs.commandName }} --instance-view)
+          echo "result=$resultMessage" >> $GITHUB_OUTPUT
     
     - name: Show the output of the command
       shell: bash

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -607,7 +607,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "findStuff"
-            script: "sudo dnf whatprovides */errno.h -y"
+            script: "sudo dnf whatprovides */linux/errno.h -y"
             
       - name: Install glibc
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -538,7 +538,7 @@ jobs:
 
   # This job runs DCAP end to end tests 
   # Mariner is based on Fedora and requires different commands from Ubuntu 
-  DCAPE2ETestMariner:    
+  MarinerBuild:    
     strategy:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
@@ -603,12 +603,6 @@ jobs:
         with:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
-            
-      #- name: Find stuff
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "findStuff"
-      #      script: "sudo dnf whatprovides */linux/errno.h -y"
             
       - name: Install kernel devel
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -288,11 +288,11 @@ jobs:
             commandName: "updateDNF"
             script: "sudo dnf check-update -y"
               
-      - name: Install buildEssential
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installBuildEssential"
-            script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
+      #- name: Install buildEssential
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "installBuildEssential"
+      #      script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
               
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -604,6 +604,18 @@ jobs:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
             
+      - name: Install the epel repository
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installEpel"
+            script: "sudo dnf install epel-release -y"
+            
+      - name: Install build packages
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installBuiltPackages"
+            script: 'sudo dnf groupinstall "Development Tools" "Development Libraries" -y'
+            
       #- name: Find stuff
       #  uses: ./.github/actions/actionAzVmRunCommand
       #  with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 1
       matrix:
         imageName: ["Ubuntu20_04", "Ubuntu18_04"]
-        sizeName: [CoffeeLake]
+        sizeName: [IceLake, CoffeeLake]
         buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
@@ -28,6 +28,10 @@ jobs:
             imageName: Ubuntu18_04
           - sizeName: CoffeeLake
             size: Standard_DC4s_v2
+            location: uksouth
+          - sizeName: IceLake
+            size: Standard_DC4s_v3
+            location: westus
           
     # OS of the Github VM calling Azure CLI
     runs-on: ubuntu-latest
@@ -35,7 +39,7 @@ jobs:
     # Job environment variables
     env:
       os: linux
-      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
+      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.sizeName }}${{ matrix.imageName }}${{ matrix.buildType }}
       rgName: dcap-github-actions-agents-rg
 
       
@@ -57,6 +61,7 @@ jobs:
               --name $vmName \
               --image ${{ matrix.imageUrn }} \
               --size ${{ matrix.size }} \
+              --location ${{ matrix.location }} \
               --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
               --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
               --nic-delete-option delete \
@@ -230,12 +235,12 @@ jobs:
       matrix:
         imageName: ["Mariner"]
         sizeName: [CoffeeLake]
-        buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
             imageName: Mariner
           - sizeName: CoffeeLake
             size: Standard_DC4s_v2
+            location: uksouth
           
     # OS of the Github VM calling Azure CLI
     runs-on: ubuntu-latest
@@ -243,7 +248,7 @@ jobs:
     # Job environment variables
     env:
       os: linux
-      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
+      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}
       rgName: dcap-github-actions-agents-rg
 
       
@@ -265,6 +270,7 @@ jobs:
               --name $vmName \
               --image ${{ matrix.imageUrn }} \
               --size ${{ matrix.size }} \
+              --location ${{ matrix.location }} \
               --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
               --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
               --nic-delete-option delete \
@@ -273,23 +279,11 @@ jobs:
       
       - name: Sleep to let the VM start
         run: sleep 60
-      
-      - name: Install software properties common
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installSoftwarePropertiesCommon"
-            script: "sudo dnf install software-properties-common -y"
               
-      - name: Add ppa repository
+      - name: Update dnf
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "addPpaRepository"
-            script: "sudo add-apt-repository ppa:team-xbmc/ppa -y"
-              
-      - name: Update apt-get
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "updateAptGet"
+            commandName: "updateDNF"
             script: "sudo dnf check-update -y"
               
       - name: Install libSSL
@@ -314,7 +308,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: "sudo apt-get install build-essential -y"
+            script: "sudo dnf install build-essential -y"
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand
@@ -548,13 +542,28 @@ jobs:
   # This job runs DCAP end to end tests 
   DCAPE2ETest:
             
+    strategy:
+      # Launch a VM and build once per each combination of linux image, VM size and buildType
+      max-parallel: 1
+      matrix:
+        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
+        sizeName: [CoffeeLake]
+        include:
+          - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
+            imageName: Ubuntu20_04
+          - imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
+            imageName: Ubuntu18_04
+          - sizeName: CoffeeLake
+            size: Standard_DC4s_v2
+            location: uksouth
+            
     # OS of the Github VM calling Azure CLI
     runs-on: ubuntu-latest
     
     # Job environment variables
     env:
       os: linux
-      vmName: dcapE2ETestBuildVM${{ github.run_number }}Ubuntu20_04
+      vmName: dcapE2ETestBuildVM${{ github.run_number }}${{ matrix.sizeName }}${{ matrix.imageName }}
       rgName: dcap-github-actions-agents-rg
 
       
@@ -574,8 +583,9 @@ jobs:
             az vm create \
               --resource-group $rgName \
               --name $vmName \
-              --image "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest" \
-              --size Standard_DC4s_v2 \
+              --image ${{ matrix.imageUrn }} \
+              --size ${{ matrix.size }} \
+              --location ${{ matrix.location }} \
               --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
               --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
               --nic-delete-option delete \

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -245,6 +245,7 @@ jobs:
       #Windows VM name must be within 15 characters
       vmName: winBuildPersSub
       rgName: dcap-github-actions-agents-rg
+      location: westus
 
       
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -274,6 +275,7 @@ jobs:
             az vm run-command create \
               --resource-group $rgName \
               --vm-name $vmName \
+              --location $location \
               --name "cloneDcap" \
               --script "C:/dcapBuild/DCAPCloneMain.ps1 -repo https://github.com/microsoft/Azure-DCAP-Client.git -branch ${{ github.head_ref }}"
               
@@ -296,6 +298,7 @@ jobs:
             az vm run-command create \
               --resource-group $rgName \
               --vm-name $vmName \
+              --location $location \
               --name "buildDcap" \
               --script "C:/dcapBuild/DCAPBuildMain.ps1 -BuildType ${{ matrix.buildType }}"
               
@@ -318,6 +321,7 @@ jobs:
             az vm run-command create \
               --resource-group $rgName \
               --vm-name $vmName \
+              --location $location \
               --name "unitTestDcap" \
               --script "C:/dcapBuild/DCAPUnitTestsMain.ps1 -BuildType ${{ matrix.buildType }}"
               

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -340,7 +340,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installLibgtest"
-            script: "sudo dnf install libgtest-devel -y"
+            script: "dnf search libgtest && sudo dnf install libgtest-devel -y"
               
       - name: Install Google test
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -292,7 +292,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: sudo dnf group install "C Development Tools and Libraries" "Development Tools" -y
+            script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
               
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -405,12 +405,6 @@ jobs:
             commandName: "updateAptGet"
             script: "sudo apt-get update -y"
               
-      - name: Show available dnf groups
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installLibSSL"
-            script: "dnf group list --hidden"
-              
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand
         with:
@@ -602,6 +596,12 @@ jobs:
         with:
             commandName: "updateDNF"
             script: "sudo dnf check-update -y"
+              
+      - name: Show available dnf groups
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibSSL"
+            script: "dnf group list --hidden"
               
       #- name: Install buildEssential
       #  uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -310,7 +310,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: 'sudo dnf group install "C Development Tools and Libraries" "Development Tools" -y'
+            script: "sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y"
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -639,6 +639,12 @@ jobs:
             commandName: "installSqlite3Dev"
             script: "sudo dnf install sqlite-devel -y"
               
+      - name: Install git
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGit"
+            script: "sudo dnf install git-all -y"
+
       - name: Install CMake
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -235,6 +235,7 @@ jobs:
       matrix:
         imageName: ["Mariner"]
         sizeName: [CoffeeLake]
+        buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
             imageName: Mariner
@@ -248,7 +249,7 @@ jobs:
     # Job environment variables
     env:
       os: linux
-      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}
+      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
       rgName: dcap-github-actions-agents-rg
 
       

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -596,24 +596,12 @@ jobs:
         with:
             commandName: "updateDNF"
             script: "sudo dnf check-update -y"
-              
-      - name: Install gcc
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installGcc"
-            script: "sudo dnf install gcc -y"
             
-      - name: Install gcc-c++
+      - name: Update packages through dnf
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "installGccplusplus"
-            script: "sudo dnf install gcc-c++ -y"
-            
-      - name: Install make
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installMake"
-            script: "sudo dnf install make -y"
+            commandName: "dnfUpgrade"
+            script: "sudo dnf upgrade -y"
             
       - name: Install glibc-devel
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -595,7 +595,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "updateDNF"
-            script: "sudo dnf check-update -y"
+            script: "sudo dnf check-update -y && sudo dnf search git"
               
       #- name: Install buildEssential
       #  uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -603,6 +603,12 @@ jobs:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
             
+      - name: Find stuff
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "findStuff"
+            script: "sudo dnf whatprovides */errno.h -y"
+            
       - name: Install glibc
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -405,6 +405,12 @@ jobs:
             commandName: "updateAptGet"
             script: "sudo apt-get update -y"
               
+      - name: Show available dnf groups
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibSSL"
+            script: "dnf group list --hidden"
+              
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -41,6 +41,7 @@ jobs:
       os: linux
       vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.sizeName }}${{ matrix.imageName }}${{ matrix.buildType }}
       rgName: dcap-github-actions-agents-rg
+      location: ${{ matrix.location }}
 
       
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -291,13 +292,13 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installLibSSL"
-            script: "sudo dnf install libssl-dev -y"
+            script: "sudo dnf install openssl-devel -y"
               
       - name: Install openSSL
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installOpenSSL"
-            script: "sudo dnf install libcurl4-openssl-dev -y"
+            script: "sudo dnf install libcurl-devel -y"
               
       - name: Install PkgConfig
         uses: ./.github/actions/actionAzVmRunCommand
@@ -309,25 +310,25 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: "sudo dnf install build-essential -y"
+            script: 'sudo dnf group install "C Development Tools and Libraries" "Development Tools" -y'
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installNlohmannJson"
-            script: "sudo dnf install nlohmann-json3-dev -y"
+            script: "sudo dnf install json-devel -y"
               
       - name: Install sqlite3
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installSqlite3"
-            script: "sudo dnf install sqlite3 -y"
+            script: "sudo dnf install sqlite -y"
               
       - name: Install sqlite3 dev
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installSqlite3Dev"
-            script: "sudo dnf install libsqlite3-dev -y"
+            script: "sudo dnf install libsq3-devel -y"
               
       - name: Install CMake
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -328,7 +328,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installSqlite3Dev"
-            script: "sudo dnf search sqlite && sudo dnf install libsqlite3x-devel -y"
+            script: "sudo dnf install sqlite-devel -y"
               
       - name: Install CMake
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -7,9 +7,7 @@ on:
   # Triggers the workflow on pull request events but only for the "master" branch
   pull_request:
     branches: [ "master" ]
-  # Manually trigger the workflow
-  workflow_dispatch:
-
+    
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -351,12 +351,12 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [CoffeeLake]
-        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
+        imageName: ["Ubuntu20_04"]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
-          - imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
-            imageName: Ubuntu18_04
+          #- imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
+          #  imageName: Ubuntu18_04
           - sizeName: CoffeeLake
             size: Standard_DC4s_v2
             location: uksouth

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -603,6 +603,12 @@ jobs:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
             
+      - name: Install glibc
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGlibc"
+            script: "sudo dnf install glibc -y"
+            
       - name: Install glibc-devel
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -310,7 +310,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: "sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y"
+            script: "sudo dnf group install 'C Development Tools and Libraries' 'Development Tools' -y"
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -328,13 +328,25 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installSqlite3Dev"
-            script: "sudo dnf install libsq3-devel -y"
+            script: "sudo dnf search sqlite && sudo dnf install libsqlite3x-devel -y"
               
       - name: Install CMake
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installCMake"
             script: "sudo dnf install cmake -y"
+            
+      - name: Install libgtest
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibgtest"
+            script: "sudo dnf install libgtest-devel -y"
+              
+      - name: Install Google test
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGoogleTest"
+            script: "cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib"
               
       - name: Clone Azure DCAP 
         uses: ./.github/actions/actionAzVmRunCommand
@@ -359,48 +371,30 @@ jobs:
         with:
             commandName: "makeAzureDcap"
             script: "cd /AzureDCAP/src/Linux && sudo make"
-                            
-      - name: Clone openenclave 
+              
+      - name: Make Install Azure DCAP
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "cloneOpenEnclave"
-            script: "sudo git clone --recursive https://github.com/openenclave/openenclave.git /openenclave"
-                            
-      - name: Update openenclave submodule
+            commandName: "makeInstallAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo make install"
+              
+      - name: CMake DCAP tests
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "updateOpenEnclaveSubmodule"
-            script: "mkdir /openenclave/build && cd /openenclave/build && sudo git submodule update --recursive --init"
-                            
-      - name: Install Ansible
+            commandName: "cmakeDcapTests"
+            script: "cd /AzureDCAP/src/Linux && cmake CMakeLists.txt"
+              
+      - name: Make DCAP tests
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "installAnsible"
-            script: "cd /openenclave && sudo scripts/ansible/install-ansible.sh"
-                            
-      - name: Setup ACC 
+            commandName: "makeDcapTests"
+            script: "cd /AzureDCAP/src/Linux/ext/intel/ && sudo cp * /usr/include/ && cd ../.. && make"
+              
+      - name: Run DCAP tests
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "setupACC"
-            script: "cd /openenclave && sudo ansible-playbook scripts/ansible/oe-contributors-acc-setup.yml"
-                            
-      - name: CMake openenclave with ninja
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "cmakeOpenEnclave"
-            script: "cd /openenclave/build && sudo cmake /openenclave -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.buildType }}"
-                            
-      - name: Make openenclave with ninja
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "makeOpenEnclave"
-            script: "cd /openenclave/build && sudo ninja -v"
-                            
-      - name: Run openenclave tests
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "testOpenEnclave"
-            script: "cd /openenclave/build && sudo LD_LIBRARY_PATH=/AzureDCAP/src/Linux ctest --output-on-failure"
+            commandName: "runDcapTests"
+            script: "cd /AzureDCAP/src/Linux && sudo /sbin/ldconfig -v && ./dcap_provider_utests"
 
       - name: If the build fails, keep the VM alive for 4 hours for debugging purposes
         if: failure()

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -688,11 +688,29 @@ jobs:
             commandName: "installBinutils"
             script: 'sudo dnf install binutils -y'
             
-      #- name: Install libgtest
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "installLibgtest"
-      #      script: "dnf search libgtest && sudo dnf install libgtest-devel -y"
+      - name: Clone GoogleTest 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cloneGoogleTest"
+            script: 'sudo git clone https://github.com/google/googletest.git /GoogleTest'
+              
+      - name: CMake GoogleTest
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cmakeGoogleTest"
+            script: "cd /GoogleTest && sudo mkdir build && cd build && sudo cmake .."
+            
+      - name: Make GoogleTest
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeGoogleTest"
+            script: "cd /GoogleTest/build && sudo make"
+            
+      - name: Make Install GoogleTest
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeInstallGoogleTest"
+            script: "cd /GoogleTest/build && sudo make install"
               
       #- name: Install Google test
       #  uses: ./.github/actions/actionAzVmRunCommand
@@ -730,23 +748,23 @@ jobs:
             commandName: "makeInstallAzureDcap"
             script: "cd /AzureDCAP/src/Linux && sudo make install"
               
-      #- name: CMake DCAP tests
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "cmakeDcapTests"
-      #      script: "cd /AzureDCAP/src/Linux && cmake CMakeLists.txt"
+      - name: CMake DCAP tests
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cmakeDcapTests"
+            script: "cd /AzureDCAP/src/Linux && cmake CMakeLists.txt"
               
-      #- name: Make DCAP tests
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "makeDcapTests"
-      #      script: "cd /AzureDCAP/src/Linux/ext/intel/ && sudo cp * /usr/include/ && cd ../.. && make"
+      - name: Make DCAP tests
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeDcapTests"
+            script: "cd /AzureDCAP/src/Linux/ext/intel/ && sudo cp * /usr/include/ && cd ../.. && make"
               
-      #- name: Run DCAP tests
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "runDcapTests"
-      #      script: "cd /AzureDCAP/src/Linux && sudo /sbin/ldconfig -v && ./dcap_provider_utests"
+      - name: Run DCAP tests
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "runDcapTests"
+            script: "cd /AzureDCAP/src/Linux && sudo /sbin/ldconfig -v && ./dcap_provider_utests"
 
       - name: If the build fails, keep the VM alive for 4 hours for debugging purposes
         if: failure()

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -226,198 +226,6 @@ jobs:
               -n ${{ env.vmName }}PublicIP \
               --resource-type "Microsoft.Network/publicIPAddresses"
               
-              
-  # This job tests running on hardware with a custom path to libdcap_quoteprov.so
-  # Mariner is based on Fedora and requires different commands from Ubuntu 
-  ACCTestMariner:    
-    strategy:
-      # Launch a VM and build once per each combination of linux image, VM size and buildType
-      max-parallel: 1
-      matrix:
-        sizeName: [CoffeeLake]
-        imageName: ["Mariner"]
-        buildType: [RelWithDebInfo, Debug]
-        include:
-          - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
-            imageName: Mariner
-          - sizeName: CoffeeLake
-            size: Standard_DC4s_v2
-            location: uksouth
-          
-    # OS of the Github VM calling Azure CLI
-    runs-on: ubuntu-latest
-    
-    # Job environment variables
-    env:
-      os: linux
-      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
-      rgName: dcap-github-actions-agents-rg
-
-      
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-          
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      
-      - name: Create VM
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az vm create \
-              --resource-group $rgName \
-              --name $vmName \
-              --image ${{ matrix.imageUrn }} \
-              --size ${{ matrix.size }} \
-              --location ${{ matrix.location }} \
-              --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
-              --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
-              --nic-delete-option delete \
-              --os-disk-delete-option delete \
-              --public-ip-sku Standard
-      
-      - name: Sleep to let the VM start
-        run: sleep 60
-              
-      - name: Update dnf
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "updateDNF"
-            script: "sudo dnf check-update -y"
-              
-      #- name: Install buildEssential
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "installBuildEssential"
-      #      script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
-              
-      - name: Install libSSL
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installLibSSL"
-            script: "sudo dnf install openssl-devel -y"
-              
-      - name: Install openSSL
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installOpenSSL"
-            script: "sudo dnf install libcurl-devel -y"
-              
-      - name: Install PkgConfig
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installPkgConfig"
-            script: "sudo dnf install pkg-config -y"
-              
-      - name: Install nlohmann json
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installNlohmannJson"
-            script: "sudo dnf install nlohmann-json-devel -y"
-              
-      - name: Install sqlite3
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installSqlite3"
-            script: "sudo dnf install sqlite -y"
-              
-      - name: Install sqlite3 dev
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installSqlite3Dev"
-            script: "sudo dnf install sqlite-devel -y"
-              
-      - name: Install CMake
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installCMake"
-            script: "sudo dnf install cmake -y"
-            
-      - name: Install libgtest
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installLibgtest"
-            script: "dnf search libgtest && sudo dnf install libgtest-devel -y"
-              
-      - name: Install Google test
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installGoogleTest"
-            script: "cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib"
-              
-      - name: Clone Azure DCAP 
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "cloneAzureDcap"
-            script: "sudo git clone -b ${{ github.head_ref }} https://github.com/microsoft/Azure-DCAP-Client.git /AzureDCAP"
-              
-      - name: Update DCAP submodule
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "updateSubmodule"
-            script: "cd /AzureDCAP && sudo git submodule update --init --recursive"
-              
-      - name: Configure Azure DCAP
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "configureAzureDcap"
-            script: "cd /AzureDCAP/src/Linux && sudo ./configure"
-              
-      - name: Make Azure DCAP
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "makeAzureDcap"
-            script: "cd /AzureDCAP/src/Linux && sudo make"
-              
-      - name: Make Install Azure DCAP
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "makeInstallAzureDcap"
-            script: "cd /AzureDCAP/src/Linux && sudo make install"
-              
-      - name: CMake DCAP tests
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "cmakeDcapTests"
-            script: "cd /AzureDCAP/src/Linux && cmake CMakeLists.txt"
-              
-      - name: Make DCAP tests
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "makeDcapTests"
-            script: "cd /AzureDCAP/src/Linux/ext/intel/ && sudo cp * /usr/include/ && cd ../.. && make"
-              
-      - name: Run DCAP tests
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "runDcapTests"
-            script: "cd /AzureDCAP/src/Linux && sudo /sbin/ldconfig -v && ./dcap_provider_utests"
-
-      - name: If the build fails, keep the VM alive for 4 hours for debugging purposes
-        if: failure()
-        run: sleep 4h
-
-      - name: Cleanup
-        if: always()
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az vm delete \
-              -g $rgName \
-              -n $vmName \
-              --yes
-            az resource delete \
-              -g $rgName \
-              -n ${{ env.vmName }}NSG \
-              --resource-type "Microsoft.Network/networkSecurityGroups"
-            az resource delete \
-              -g $rgName \
-              -n ${{ env.vmName }}PublicIP \
-              --resource-type "Microsoft.Network/publicIPAddresses"
-
 
   # Test DCAP build process in Windows
   DCAPWindowsBuildTest:          
@@ -728,4 +536,194 @@ jobs:
               --resource-type "Microsoft.Network/publicIPAddresses"
               
 
+  # This job runs DCAP end to end tests 
+  # Mariner is based on Fedora and requires different commands from Ubuntu 
+  DCAPE2ETestMariner:    
+    strategy:
+      # Launch a VM and build once per each combination of linux image, VM size and buildType
+      max-parallel: 1
+      matrix:
+        sizeName: [CoffeeLake]
+        imageName: ["Mariner"]
+        buildType: [RelWithDebInfo, Debug]
+        include:
+          - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
+            imageName: Mariner
+          - sizeName: CoffeeLake
+            size: Standard_DC4s_v2
+            location: uksouth
+          
+    # OS of the Github VM calling Azure CLI
+    runs-on: ubuntu-latest
+    
+    # Job environment variables
+    env:
+      os: linux
+      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
+      rgName: dcap-github-actions-agents-rg
+
       
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+          
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      
+      - name: Create VM
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az vm create \
+              --resource-group $rgName \
+              --name $vmName \
+              --image ${{ matrix.imageUrn }} \
+              --size ${{ matrix.size }} \
+              --location ${{ matrix.location }} \
+              --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
+              --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
+              --nic-delete-option delete \
+              --os-disk-delete-option delete \
+              --public-ip-sku Standard
+      
+      - name: Sleep to let the VM start
+        run: sleep 60
+              
+      - name: Update dnf
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "updateDNF"
+            script: "sudo dnf check-update -y"
+              
+      #- name: Install buildEssential
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "installBuildEssential"
+      #      script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
+              
+      - name: Install libSSL
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibSSL"
+            script: "sudo dnf install openssl-devel -y"
+              
+      - name: Install openSSL
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installOpenSSL"
+            script: "sudo dnf install libcurl-devel -y"
+              
+      - name: Install PkgConfig
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installPkgConfig"
+            script: "sudo dnf install pkg-config -y"
+              
+      - name: Install nlohmann json
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installNlohmannJson"
+            script: "sudo dnf install nlohmann-json-devel -y"
+              
+      - name: Install sqlite3
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installSqlite3"
+            script: "sudo dnf install sqlite -y"
+              
+      - name: Install sqlite3 dev
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installSqlite3Dev"
+            script: "sudo dnf install sqlite-devel -y"
+              
+      - name: Install CMake
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installCMake"
+            script: "sudo dnf install cmake -y"
+            
+      #- name: Install libgtest
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "installLibgtest"
+      #      script: "dnf search libgtest && sudo dnf install libgtest-devel -y"
+              
+      #- name: Install Google test
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "installGoogleTest"
+      #      script: "cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib"
+              
+      - name: Clone Azure DCAP 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cloneAzureDcap"
+            script: "sudo git clone -b ${{ github.head_ref }} https://github.com/microsoft/Azure-DCAP-Client.git /AzureDCAP"
+              
+      - name: Update DCAP submodule
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "updateSubmodule"
+            script: "cd /AzureDCAP && sudo git submodule update --init --recursive"
+              
+      - name: Configure Azure DCAP
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "configureAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo ./configure"
+              
+      - name: Make Azure DCAP
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo make"
+              
+      - name: Make Install Azure DCAP
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeInstallAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo make install"
+              
+      #- name: CMake DCAP tests
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "cmakeDcapTests"
+      #      script: "cd /AzureDCAP/src/Linux && cmake CMakeLists.txt"
+              
+      #- name: Make DCAP tests
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "makeDcapTests"
+      #      script: "cd /AzureDCAP/src/Linux/ext/intel/ && sudo cp * /usr/include/ && cd ../.. && make"
+              
+      #- name: Run DCAP tests
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "runDcapTests"
+      #      script: "cd /AzureDCAP/src/Linux && sudo /sbin/ldconfig -v && ./dcap_provider_utests"
+
+      - name: If the build fails, keep the VM alive for 4 hours for debugging purposes
+        if: failure()
+        run: sleep 4h
+
+      - name: Cleanup
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az vm delete \
+              -g $rgName \
+              -n $vmName \
+              --yes
+            az resource delete \
+              -g $rgName \
+              -n ${{ env.vmName }}NSG \
+              --resource-type "Microsoft.Network/networkSecurityGroups"
+            az resource delete \
+              -g $rgName \
+              -n ${{ env.vmName }}PublicIP \
+              --resource-type "Microsoft.Network/publicIPAddresses"
+

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -606,7 +606,7 @@ jobs:
       - name: Install gcc-c++
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "installGcc-c++"
+            commandName: "installGccplusplus"
             script: "sudo dnf install gcc-c++ -y"
             
       - name: Install make

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installNlohmannJson"
-            script: "sudo dnf install json-devel-3 -y"
+            script: "sudo dnf search json-devel && sudo dnf install json-devel -y"
               
       - name: Install sqlite3
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -604,18 +604,6 @@ jobs:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
             
-      - name: Install the epel repository
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installEpel"
-            script: "sudo dnf install epel-release -y"
-            
-      - name: Install build packages
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installBuiltPackages"
-            script: 'sudo dnf groupinstall "Development Tools" "Development Libraries" -y'
-            
       #- name: Find stuff
       #  uses: ./.github/actions/actionAzVmRunCommand
       #  with:
@@ -693,6 +681,36 @@ jobs:
         with:
             commandName: "installCMake"
             script: "sudo dnf install cmake -y"
+            
+      - name: Install glibc-headers
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGlibcHeaders"
+            script: 'sudo dnf install glibc-headers -y'
+            
+      - name: Install kernel-headers
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installKernelHeaders"
+            script: 'sudo dnf install kernel-headers -y'
+            
+      - name: Install libtool 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibtool"
+            script: 'sudo dnf install libtool -y'
+            
+      - name: Install libmpc 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibmpc"
+            script: 'sudo dnf install libmpc -y'
+            
+      - name: Install libmpc 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibmpc"
+            script: 'sudo dnf install libmpc -y'
             
       #- name: Install libgtest
       #  uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -18,8 +18,8 @@ jobs:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
       matrix:
-        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
         sizeName: [IceLake, CoffeeLake]
+        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
         buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
@@ -234,8 +234,8 @@ jobs:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
       matrix:
-        imageName: ["Mariner"]
         sizeName: [CoffeeLake]
+        imageName: ["Mariner"]
         buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installNlohmannJson"
-            script: "sudo dnf install json-devel -y"
+            script: "sudo dnf install json-devel-3 -y"
               
       - name: Install sqlite3
         uses: ./.github/actions/actionAzVmRunCommand
@@ -548,8 +548,8 @@ jobs:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
       matrix:
-        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
         sizeName: [CoffeeLake]
+        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -595,7 +595,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "updateDNF"
-            script: "sudo dnf check-update -y && sudo dnf search git"
+            script: "sudo dnf check-update -y"
               
       #- name: Install buildEssential
       #  uses: ./.github/actions/actionAzVmRunCommand
@@ -643,7 +643,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installGit"
-            script: "sudo dnf install git-all -y"
+            script: "sudo dnf install git -y"
 
       - name: Install CMake
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -288,6 +288,12 @@ jobs:
             commandName: "updateDNF"
             script: "sudo dnf check-update -y"
               
+      - name: Install buildEssential
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installBuildEssential"
+            script: sudo dnf group install "C Development Tools and Libraries" "Development Tools" -y
+              
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand
         with:
@@ -305,12 +311,6 @@ jobs:
         with:
             commandName: "installPkgConfig"
             script: "sudo dnf install pkg-config -y"
-              
-      - name: Install buildEssential
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installBuildEssential"
-            script: "sudo dnf group install 'C Development Tools and Libraries' 'Development Tools' -y"
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -586,7 +586,8 @@ jobs:
               --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
               --nic-delete-option delete \
               --os-disk-delete-option delete \
-              --public-ip-sku Standard
+              --public-ip-sku Standard \
+              --os-disk-size-gb 10
       
       - name: Sleep to let the VM start
         run: sleep 60

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -279,17 +279,12 @@ jobs:
               --name "cloneDcap" \
               --script "C:/dcapBuild/DCAPCloneMain.ps1 -repo https://github.com/microsoft/Azure-DCAP-Client.git -branch ${{ github.head_ref }}"
               
-      - name: Get the build result
-        id: cloneDcapResult
+      - name: Get the result of cloning the repository
         shell: bash
         run: |
-            echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "cloneDcap" --instance-view)'
-    
-      - name: Verify the build result
-        shell: bash
-        run: |
-            echo -e ${{steps.cloneDcapResult.outputs.result}} 
-            if [[ "${{steps.cloneDcapResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+            result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "cloneDcap" --instance-view)
+            echo -e "$result"
+            if [[ "$result" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi
              
       - name: Build Azure DCAP
         uses: azure/CLI@v1
@@ -302,17 +297,12 @@ jobs:
               --name "buildDcap" \
               --script "C:/dcapBuild/DCAPBuildMain.ps1 -BuildType ${{ matrix.buildType }}"
               
-      - name: Get the build result
-        id: buildDcapResult
+      - name: Get the result of building dcap
         shell: bash
         run: |
-            echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "buildDcap" --instance-view)'
-    
-      - name: Verify the build result
-        shell: bash
-        run: |
-            echo -e ${{steps.buildDcapResult.outputs.result}} 
-            if [[ "${{steps.buildDcapResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+            result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "buildDcap" --instance-view)
+            echo -e "$result"
+            if [[ "$result" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi
       
       - name: Run Azure DCAP unit tests
         uses: azure/CLI@v1
@@ -325,17 +315,12 @@ jobs:
               --name "unitTestDcap" \
               --script "C:/dcapBuild/DCAPUnitTestsMain.ps1 -BuildType ${{ matrix.buildType }}"
               
-      - name: Get the build result
-        id: unitTestDcapResult
+      - name: Get the result of the unit tests
         shell: bash
         run: |
-            echo '::set-output name=result::$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "unitTestDcap" --instance-view)'
-    
-      - name: Verify the build result
-        shell: bash
-        run: |
-            echo -e ${{steps.unitTestDcapResult.outputs.result}} 
-            if [[ "${{steps.unitTestDcapResult.outputs.result}}" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi 
+            result=$(az vm run-command show --resource-group $rgName --vm-name $vmName --name "unitTestDcap" --instance-view)
+            echo -e "$result"
+            if [[ "$result" == *"DCAP_Build_Step_Successfully_Completed"* ]]; then echo "Step successfully executed"; else exit 1; fi
 
       - name: Stop VM
         if: always()
@@ -349,7 +334,6 @@ jobs:
 
   # This job runs DCAP end to end tests 
   DCAPE2ETest:
-            
     strategy:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -603,11 +603,23 @@ jobs:
             commandName: "dnfUpgrade"
             script: "sudo dnf upgrade -y"
             
-      - name: Find stuff
+      #- name: Find stuff
+      #  uses: ./.github/actions/actionAzVmRunCommand
+      #  with:
+      #      commandName: "findStuff"
+      #      script: "sudo dnf whatprovides */linux/errno.h -y"
+            
+      - name: Install kernel devel
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "findStuff"
-            script: "sudo dnf whatprovides */linux/errno.h -y"
+            commandName: "installKernelDevel"
+            script: "sudo dnf install kernel-devel -y"
+            
+      - name: Install automake
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installAutomake"
+            script: "sudo dnf install automake -y"
             
       - name: Install glibc
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -597,17 +597,29 @@ jobs:
             commandName: "updateDNF"
             script: "sudo dnf check-update -y"
               
-      - name: Show available dnf groups
+      - name: Install gcc
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "installLibSSL"
-            script: "dnf group list --hidden"
-              
-      #- name: Install buildEssential
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "installBuildEssential"
-      #      script: sudo dnf group install \"C Development Tools and Libraries\" \"Development Tools\" -y
+            commandName: "installGcc"
+            script: "sudo dnf install gcc -y"
+            
+      - name: Install gcc-c++
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGcc-c++"
+            script: "sudo dnf install gcc-c++ -y"
+            
+      - name: Install make
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installMake"
+            script: "sudo dnf install make -y"
+            
+      - name: Install glibc-devel
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installGlibc-devel"
+            script: "sudo dnf install glibc-devel -y"
               
       - name: Install libSSL
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -700,12 +700,6 @@ jobs:
             commandName: "makeInstallGoogleTest"
             script: "cd /GoogleTest/build && sudo make install"
               
-      #- name: Install Google test
-      #  uses: ./.github/actions/actionAzVmRunCommand
-      #  with:
-      #      commandName: "installGoogleTest"
-      #      script: "cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && cd lib && sudo cp *.a /usr/lib"
-              
       - name: Clone Azure DCAP 
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -243,7 +243,7 @@ jobs:
     env:
       os: windows
       #Windows VM name must be within 15 characters
-      vmName: winBuildPers
+      vmName: winBuildPersSub
       rgName: dcap-github-actions-agents-rg
 
       

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -316,7 +316,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installNlohmannJson"
-            script: "sudo dnf search json-devel && sudo dnf install json-devel -y"
+            script: "sudo dnf install nlohmann-json-devel -y"
               
       - name: Install sqlite3
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -18,10 +18,12 @@ jobs:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
       matrix:
-        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
+        imageName: ["Mariner", "Ubuntu20_04", "Ubuntu18_04"]
         sizeName: [CoffeeLake]
         buildType: [RelWithDebInfo, Debug]
         include:
+          - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
+            imageName: Mariner
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
           - imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -682,35 +682,17 @@ jobs:
             commandName: "installCMake"
             script: "sudo dnf install cmake -y"
             
-      - name: Install glibc-headers
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installGlibcHeaders"
-            script: 'sudo dnf install glibc-headers -y'
-            
       - name: Install kernel-headers
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installKernelHeaders"
             script: 'sudo dnf install kernel-headers -y'
             
-      - name: Install libtool 
+      - name: Install binutils 
         uses: ./.github/actions/actionAzVmRunCommand
         with:
-            commandName: "installLibtool"
-            script: 'sudo dnf install libtool -y'
-            
-      - name: Install libmpc 
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installLibmpc"
-            script: 'sudo dnf install libmpc -y'
-            
-      - name: Install libmpc 
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installLibmpc"
-            script: 'sudo dnf install libmpc -y'
+            commandName: "installBinutils"
+            script: 'sudo dnf install binutils -y'
             
       #- name: Install libgtest
       #  uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -72,7 +72,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installSoftwarePropertiesCommon"
-            script: "sudo apt install software-properties-common -y"
+            script: "sudo apt-get install software-properties-common -y"
               
       - name: Add ppa repository
         uses: ./.github/actions/actionAzVmRunCommand
@@ -96,7 +96,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installOpenSSL"
-            script: "sudo apt install libcurl4-openssl-dev -y"
+            script: "sudo apt-get install libcurl4-openssl-dev -y"
               
       - name: Install PkgConfig
         uses: ./.github/actions/actionAzVmRunCommand
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/actionAzVmRunCommand
         with:
             commandName: "installBuildEssential"
-            script: "sudo apt install build-essential -y"
+            script: "sudo apt-get install build-essential -y"
               
       - name: Install nlohmann json
         uses: ./.github/actions/actionAzVmRunCommand

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -18,12 +18,10 @@ jobs:
       # Launch a VM and build once per each combination of linux image, VM size and buildType
       max-parallel: 1
       matrix:
-        imageName: ["Mariner", "Ubuntu20_04", "Ubuntu18_04"]
+        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
         sizeName: [CoffeeLake]
         buildType: [RelWithDebInfo, Debug]
         include:
-          - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
-            imageName: Mariner
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
           - imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
@@ -133,6 +131,214 @@ jobs:
         with:
             commandName: "installCMake"
             script: "sudo apt-get install cmake -y"
+              
+      - name: Clone Azure DCAP 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cloneAzureDcap"
+            script: "sudo git clone -b ${{ github.head_ref }} https://github.com/microsoft/Azure-DCAP-Client.git /AzureDCAP"
+              
+      - name: Update DCAP submodule
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "updateSubmodule"
+            script: "cd /AzureDCAP && sudo git submodule update --init --recursive"
+              
+      - name: Configure Azure DCAP
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "configureAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo ./configure"
+              
+      - name: Make Azure DCAP
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeAzureDcap"
+            script: "cd /AzureDCAP/src/Linux && sudo make"
+                            
+      - name: Clone openenclave 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cloneOpenEnclave"
+            script: "sudo git clone --recursive https://github.com/openenclave/openenclave.git /openenclave"
+                            
+      - name: Update openenclave submodule
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "updateOpenEnclaveSubmodule"
+            script: "mkdir /openenclave/build && cd /openenclave/build && sudo git submodule update --recursive --init"
+                            
+      - name: Install Ansible
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installAnsible"
+            script: "cd /openenclave && sudo scripts/ansible/install-ansible.sh"
+                            
+      - name: Setup ACC 
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "setupACC"
+            script: "cd /openenclave && sudo ansible-playbook scripts/ansible/oe-contributors-acc-setup.yml"
+                            
+      - name: CMake openenclave with ninja
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "cmakeOpenEnclave"
+            script: "cd /openenclave/build && sudo cmake /openenclave -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.buildType }}"
+                            
+      - name: Make openenclave with ninja
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "makeOpenEnclave"
+            script: "cd /openenclave/build && sudo ninja -v"
+                            
+      - name: Run openenclave tests
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "testOpenEnclave"
+            script: "cd /openenclave/build && sudo LD_LIBRARY_PATH=/AzureDCAP/src/Linux ctest --output-on-failure"
+
+      - name: If the build fails, keep the VM alive for 4 hours for debugging purposes
+        if: failure()
+        run: sleep 4h
+
+      - name: Cleanup
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az vm delete \
+              -g $rgName \
+              -n $vmName \
+              --yes
+            az resource delete \
+              -g $rgName \
+              -n ${{ env.vmName }}NSG \
+              --resource-type "Microsoft.Network/networkSecurityGroups"
+            az resource delete \
+              -g $rgName \
+              -n ${{ env.vmName }}PublicIP \
+              --resource-type "Microsoft.Network/publicIPAddresses"
+              
+              
+  # This job tests running on hardware with a custom path to libdcap_quoteprov.so
+  # Mariner is based on Fedora and requires different commands from Ubuntu 
+  ACCTestMariner:          
+    strategy:
+      # Launch a VM and build once per each combination of linux image, VM size and buildType
+      max-parallel: 1
+      matrix:
+        imageName: ["Mariner"]
+        sizeName: [CoffeeLake]
+        buildType: [RelWithDebInfo, Debug]
+        include:
+          - imageUrn: "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:latest"
+            imageName: Mariner
+          - sizeName: CoffeeLake
+            size: Standard_DC4s_v2
+          
+    # OS of the Github VM calling Azure CLI
+    runs-on: ubuntu-latest
+    
+    # Job environment variables
+    env:
+      os: linux
+      vmName: dcapACCTestBuildVM${{ github.run_number }}${{ matrix.imageName }}${{ matrix.buildType }}
+      rgName: dcap-github-actions-agents-rg
+
+      
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+          
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      
+      - name: Create VM
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az vm create \
+              --resource-group $rgName \
+              --name $vmName \
+              --image ${{ matrix.imageUrn }} \
+              --size ${{ matrix.size }} \
+              --admin-username ${{ secrets.BUILD_VM_USERNAME }} \
+              --admin-password ${{ secrets.BUILD_VM_PASSWORD }} \
+              --nic-delete-option delete \
+              --os-disk-delete-option delete \
+              --public-ip-sku Standard
+      
+      - name: Sleep to let the VM start
+        run: sleep 60
+      
+      - name: Install software properties common
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installSoftwarePropertiesCommon"
+            script: "sudo dnf install software-properties-common -y"
+              
+      - name: Add ppa repository
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "addPpaRepository"
+            script: "sudo add-apt-repository ppa:team-xbmc/ppa -y"
+              
+      - name: Update apt-get
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "updateAptGet"
+            script: "sudo dnf check-update -y"
+              
+      - name: Install libSSL
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installLibSSL"
+            script: "sudo dnf install libssl-dev -y"
+              
+      - name: Install openSSL
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installOpenSSL"
+            script: "sudo dnf install libcurl4-openssl-dev -y"
+              
+      - name: Install PkgConfig
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installPkgConfig"
+            script: "sudo dnf install pkg-config -y"
+              
+      - name: Install buildEssential
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installBuildEssential"
+            script: "sudo apt-get install build-essential -y"
+              
+      - name: Install nlohmann json
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installNlohmannJson"
+            script: "sudo dnf install nlohmann-json3-dev -y"
+              
+      - name: Install sqlite3
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installSqlite3"
+            script: "sudo dnf install sqlite3 -y"
+              
+      - name: Install sqlite3 dev
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installSqlite3Dev"
+            script: "sudo dnf install libsqlite3-dev -y"
+              
+      - name: Install CMake
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installCMake"
+            script: "sudo dnf install cmake -y"
               
       - name: Clone Azure DCAP 
         uses: ./.github/actions/actionAzVmRunCommand


### PR DESCRIPTION
Added building and E2E tests for Linux Mariner
Added Icelake nodes to the ACC Linux hardware test
Updated the pipeline to not use set-output since it's getting disabled in the future
Changed the windows build VM name since the current one is occupied by a VM that has to be debugged.