### PR TITLE
Remove Ubuntu 18.04 support

### DIFF
--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -19,13 +19,11 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [IceLake, CoffeeLake]
-        imageName: ["Ubuntu20_04", "Ubuntu18_04"]
+        imageName: ["Ubuntu20_04"]
         buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
-          - imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
-            imageName: Ubuntu18_04
           - sizeName: CoffeeLake
             size: Standard_DC4s_v2
             location: uksouth
@@ -352,8 +350,6 @@ jobs:
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
-          #- imageUrn: "Canonical:UbuntuServer:18_04-lts-gen2:latest"
-          #  imageName: Ubuntu18_04
           - sizeName: CoffeeLake
             size: Standard_DC4s_v2
             location: westus

--- a/src/Linux/debian/changelog
+++ b/src/Linux/debian/changelog
@@ -1,3 +1,8 @@
+az-dcap-client (1.12.1) stable; urgency=medium
+  * Removed support for Ubuntu 18.04
+
+ -- Francisco Javier Ortega Palacios<fortegapalac@microsoft.com>  Mon, 10 July 2023 15:40:00 +0000
+
 az-dcap-client (1.12.0) stable; urgency=medium
   * Added support for TDX quote validation through the following API 
   * quote3_error_t tdx_ql_get_quote_verification_collateral(const uint8_t *fmspc, uint16_t fmspc_size, const char *pck_ca, tdx_ql_qve_collateral_t **pp_quote_collateral)


### PR DESCRIPTION
The issue
Ubuntu 18.04 reached EOS in April 2023

What was done
- Removed support for Ubuntu 18.04 in the build pipeline.
- Changed the debian changelog to reflect the removal of support

Testing
Tested by running the pipeline. No changes were made to the binaries, so no need to make tests there.