### PR TITLE
Skip primary fetch if it failed recently

### DIFF
--- a/src/Windows/curl_easy.cpp
+++ b/src/Windows/curl_easy.cpp
@@ -229,6 +229,19 @@ std::unique_ptr<curl_easy> curl_easy::create(
                 curl->sessionHandle.get(), 0, 60000, 1000, 1000))
             throw_on_error(GetLastError(), "Error %u in WinHttpSetTimeouts.\n");
     }
+	
+	//WINHTTP_NO_CLIENT_CERT_CONTEXT value is null
+	//Setting a DWORD variable to it like in other WinHttpSetOption will break things 
+    if (!WinHttpSetOption(
+	        curl->request.get(), 
+	        WINHTTP_OPTION_CLIENT_CERT_CONTEXT, 
+	        WINHTTP_NO_CLIENT_CERT_CONTEXT, 
+	        0)) 
+    {
+        throw_on_error(
+            GetLastError(),
+            "curl_easy::create/WinHttpSetOption(ClientCertContext)");
+    }
 
     // Specify TLS 1.2
     DWORD protocolOptions =

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -118,7 +118,7 @@ static std::string region_cache_name = REGION_CACHE_NAME;
 
 static const string CACHE_CONTROL_MAX_AGE = "max-age=";
 
-static const int timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds = 30;
+static const int SKIP_PRIMARY_AFTER_PRIMARY_FAILURE_THRESHOLD_IN_SECONDS = 30;
 //Defaults to the unix epoch if it hasn't been set.
 static std::chrono::time_point<std::chrono::system_clock> timeOfLastPrimaryFailure;
 
@@ -1791,14 +1791,15 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
             {
                 log(SGX_QL_LOG_INFO,
                     "Checking if primary fetch failed within the last %i seconds.",
-                    timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
+                    SKIP_PRIMARY_AFTER_PRIMARY_FAILURE_THRESHOLD_IN_SECONDS);
 
                 auto timeSinceLastPrimaryFailure = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - timeOfLastPrimaryFailure);
 
-                if (timeSinceLastPrimaryFailure.count() > timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds)
+                if (timeSinceLastPrimaryFailure.count() > SKIP_PRIMARY_AFTER_PRIMARY_FAILURE_THRESHOLD_IN_SECONDS)
                 {
                     log(SGX_QL_LOG_INFO,
-                        "No primary fetch failure happened within the time threshold");
+                        "No primary fetch failure happened within the %i seconds time threshold",
+						SKIP_PRIMARY_AFTER_PRIMARY_FAILURE_THRESHOLD_IN_SECONDS);
 
                     log(SGX_QL_LOG_INFO,
                         "Trying to fetch response from primary URL: '%s'.",
@@ -1824,7 +1825,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
                 {
                     log(SGX_QL_LOG_WARNING,
                         "Primary fetch skipped since it failed within the last %i seconds.",
-                        timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
+                        SKIP_PRIMARY_AFTER_PRIMARY_FAILURE_THRESHOLD_IN_SECONDS);
                 }
             }
 #endif

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1788,44 +1788,44 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
         {
 #if !defined __SERVICE_VM__
             if (bypass_base.compare("false") == 0)
-			{
-				log(SGX_QL_LOG_INFO,
-					"Checking if primary fetch failed within the last %i seconds.",
-					timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
+            {
+                log(SGX_QL_LOG_INFO,
+                    "Checking if primary fetch failed within the last %i seconds.",
+                    timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
 
-				auto timeSinceLastPrimaryFailure = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - timeOfLastPrimaryFailure);
+                auto timeSinceLastPrimaryFailure = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - timeOfLastPrimaryFailure);
 
-				if (timeSinceLastPrimaryFailure.count() > timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds)
-				{
-					log(SGX_QL_LOG_INFO,
-						"No primary fetch failure happened within the time threshold");
+                if (timeSinceLastPrimaryFailure.count() > timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds)
+                {
+                    log(SGX_QL_LOG_INFO,
+                        "No primary fetch failure happened within the time threshold");
 
-					log(SGX_QL_LOG_INFO,
-						"Trying to fetch response from primary URL: '%s'.",
-						primary_base_url.c_str());
-					recieved_certificate = fetch_response(
-						primary_base_url,
-						curl,
-						headers::localhost_metadata,
-						retval,
-						0,
-						true);
+                    log(SGX_QL_LOG_INFO,
+                        "Trying to fetch response from primary URL: '%s'.",
+                        primary_base_url.c_str());
+                    recieved_certificate = fetch_response(
+                        primary_base_url,
+                        curl,
+                        headers::localhost_metadata,
+                        retval,
+                        0,
+                        true);
 
-					if (!recieved_certificate)
-					{
-						timeOfLastPrimaryFailure = std::chrono::system_clock::now();
+                    if (!recieved_certificate)
+                    {
+                        timeOfLastPrimaryFailure = std::chrono::system_clock::now();
 
-						log(SGX_QL_LOG_ERROR,
-							"Failed to fetch certificate from primary URL: '%s'.",
-							primary_base_url.c_str());
-					}
-				}
-				else
-				{
-					log(SGX_QL_LOG_WARNING,
-						"Primary fetch skipped since it failed within the last %i seconds.",
-						timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
-				}
+                        log(SGX_QL_LOG_ERROR,
+                            "Failed to fetch certificate from primary URL: '%s'.",
+                            primary_base_url.c_str());
+                    }
+                }
+                else
+                {
+                    log(SGX_QL_LOG_WARNING,
+                        "Primary fetch skipped since it failed within the last %i seconds.",
+                        timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds);
+                }
             }
 #endif
 

--- a/src/dcap_provider.cpp
+++ b/src/dcap_provider.cpp
@@ -1761,39 +1761,6 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
     const sgx_ql_pck_cert_id_t* p_pck_cert_id,
     sgx_ql_config_t** pp_quote_config)
 {
-
-	
-
-	
-	log(SGX_QL_LOG_INFO, "Making request to https://thimt3-dev-cbn01p.thim.azure-test.net/sgx/certification/v4/pckcrl?ca=platform.");
-
-    const auto curl_operation = curl_easy::create("https://thimt3-dev-cbn01p.thim.azure-test.net/sgx/certification/v4/pckcrl?ca=platform", nullptr);
-
-    curl_operation->perform();
-	std::string issuer_chain;
-    auto get_issuer_chain_operation =
-        get_unescape_header(*curl_operation, headers::CRL_ISSUER_CHAIN, &issuer_chain);
-    quote3_error_t retval = convert_to_intel_error(get_issuer_chain_operation);
-    if (retval == SGX_QL_SUCCESS)
-    {
-        log(SGX_QL_LOG_INFO,
-            "CRL Issuer Header is good.");
-        std::string cache_control;
-        auto get_cache_header_operation = get_unescape_header(*curl_operation, headers::CACHE_CONTROL, &cache_control);
-        retval = convert_to_intel_error(get_cache_header_operation);
-        if (retval == SGX_QL_SUCCESS)
-        {
-			log(SGX_QL_LOG_INFO,
-				"Cache control header is good.");
-        }
-    }
-	
-
-	log(SGX_QL_LOG_INFO, "Curl operation to https://thimt3-dev-cbn01p.thim.azure-test.net/sgx/certification/v4/pckcrl?ca=platform performed successfully.");
-
-	return SGX_QL_ERROR_UNEXPECTED;
-	
-
     *pp_quote_config = nullptr;
 
     try
@@ -1831,7 +1798,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
 				if (timeSinceLastPrimaryFailure.count() > timeThresholdToSkipPrimaryIfItFailedRecentlyInSeconds)
 				{
 					log(SGX_QL_LOG_INFO,
-						"Recent primary failure check passed. No Primary failure happened within the time threshold");
+						"No primary fetch failure happened within the time threshold");
 
 					log(SGX_QL_LOG_INFO,
 						"Trying to fetch response from primary URL: '%s'.",
@@ -1861,7 +1828,7 @@ extern "C" quote3_error_t sgx_ql_get_quote_config(
 				}
             }
 #endif
-	return SGX_QL_ERROR_UNEXPECTED;
+
             if (recieved_certificate)
             {
                 log(SGX_QL_LOG_INFO,


### PR DESCRIPTION
The issue
DCAP takes too long to respond in certain situations where the primary fetch is unavailable

What was done
DCAP now registers in memory the time of the last failure when fetching from primary and checks it before fetching from primary. If it happened too recently, it skips the fetch.

Testing
Tested manually that it skips primary after a recent failure and that it returns to fetching from primary after the time threshold for the failure has been crossed.
E2E and unit tests pass