### PR TITLE
Adding support for Ubuntu 22.04

### DIFF
--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -22,9 +22,11 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [IceLake, CoffeeLake]
-        imageName: ["Ubuntu20_04"]
+        imageName: ["Ubuntu20_04", "Ubuntu22_04"]
         buildType: [RelWithDebInfo, Debug]
         include:
+          - imageUrn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+            imageName: Ubuntu22_04
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
           - sizeName: CoffeeLake
@@ -352,8 +354,10 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [CoffeeLake]
-        imageName: ["Ubuntu20_04"]
+        imageName: ["Ubuntu20_04", "Ubuntu22_04"]
         include:
+          - imageUrn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+            imageName: Ubuntu22_04
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
           - sizeName: CoffeeLake

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -143,6 +143,18 @@ jobs:
             commandName: "installCMake"
             script: "sudo apt-get install cmake -y"
               
+      - name: Downgrade to libssl 1.1.1f for OE requirements
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installCMake"
+            script: "sudo wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb && sudo dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"
+              
+      - name: Downgrade to libssl-dev 1.1.1f for OE requirements
+        uses: ./.github/actions/actionAzVmRunCommand
+        with:
+            commandName: "installCMake"
+            script: "sudo wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.23_amd64.deb && dpkg -i ./libssl-dev_1.1.1f-1ubuntu2.23_amd64.deb"
+              
       - name: Clone Azure DCAP 
         uses: ./.github/actions/actionAzVmRunCommand
         with:

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -25,8 +25,6 @@ jobs:
         imageName: ["Ubuntu20_04"]
         buildType: [RelWithDebInfo, Debug]
         include:
-          - imageUrn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
-            imageName: Ubuntu22_04
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"
             imageName: Ubuntu20_04
           - sizeName: CoffeeLake

--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [IceLake, CoffeeLake]
-        imageName: ["Ubuntu20_04", "Ubuntu22_04"]
+        imageName: ["Ubuntu20_04"]
         buildType: [RelWithDebInfo, Debug]
         include:
           - imageUrn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
@@ -142,18 +142,6 @@ jobs:
         with:
             commandName: "installCMake"
             script: "sudo apt-get install cmake -y"
-              
-      - name: Downgrade to libssl 1.1.1f for OE requirements
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installCMake"
-            script: "sudo wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb && sudo dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb"
-              
-      - name: Downgrade to libssl-dev 1.1.1f for OE requirements
-        uses: ./.github/actions/actionAzVmRunCommand
-        with:
-            commandName: "installCMake"
-            script: "sudo wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.23_amd64.deb && dpkg -i ./libssl-dev_1.1.1f-1ubuntu2.23_amd64.deb"
               
       - name: Clone Azure DCAP 
         uses: ./.github/actions/actionAzVmRunCommand

--- a/src/Linux/local_cache.cpp
+++ b/src/Linux/local_cache.cpp
@@ -243,7 +243,7 @@ static void init()
 
 static std::string sha256(size_t data_size, const void* data)
 {
-    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned char hash[SHA256_DIGEST_LENGTH];
     const EVP_MD *digestType = EVP_sha256();
     int rc = EVP_Digest(data, data_size, hash, NULL, digestType, NULL);
     if (rc != 1)

--- a/src/Linux/local_cache.cpp
+++ b/src/Linux/local_cache.cpp
@@ -11,6 +11,7 @@
 #include <ftw.h>
 #include <locale.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #include <pwd.h>
 #include <unistd.h>
 #include <sys/file.h>
@@ -242,11 +243,13 @@ static void init()
 
 static std::string sha256(size_t data_size, const void* data)
 {
-    unsigned char hash[SHA256_DIGEST_LENGTH];
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, data, data_size);
-    SHA256_Final(hash, &sha256);
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    const EVP_MD *digestType = EVP_sha256();
+    int rc = EVP_Digest(data, data_size, hash, NULL, digestType, NULL);
+    if (rc != 1)
+    {
+        throw std::runtime_error("EVP_Digest failed to generate a hash for the cached file name");
+    }
 
     std::string retval;
     retval.reserve(2 * sizeof(hash) + 1);


### PR DESCRIPTION
This PR adds the changes required for Azure DCAP to run in ubuntu 22.04. 
It replaces some Deprecated OpenSSL calls for their modern equivalent and adds Ubuntu 22.04 to the tests run by the build pipeline.

Credit to @achamayou for [the following PR](https://github.com/microsoft/Azure-DCAP-Client/pull/182) upon which the changes made in this PR are based.