### PR TITLE
Add ubuntu24.04 support

### DIFF
--- a/.github/workflows/buildPipeline.yml
+++ b/.github/workflows/buildPipeline.yml
@@ -352,8 +352,10 @@ jobs:
       max-parallel: 1
       matrix:
         sizeName: [CoffeeLake]
-        imageName: ["Ubuntu20_04", "Ubuntu22_04"]
+        imageName: ["Ubuntu20_04", "Ubuntu22_04", "Ubuntu24_04"]
         include:
+          - imageUrn: "Canonical:ubuntu-24_04-lts:server:latest"
+          - imageName: Ubuntu24_04
           - imageUrn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
             imageName: Ubuntu22_04
           - imageUrn: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest"


### PR DESCRIPTION
This PR adds support for Azure DCAP client to run in ubuntu 24.04. I am planning to migrate from from ubuntu 20.04 to 24.04 and hence require support for it.

This PR is based on [ubuntu 22.04](https://github.com/microsoft/Azure-DCAP-Client/pull/200) support added by @FranciscoJavierOrtegaPalacios.

